### PR TITLE
Add functions to write simple structs to a network buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Possibility to flip decoded jpeg images
 - Custom key codes
+- Methods to read and write structs from network buffers
 
 ### Changed
 

--- a/atcg_lib/include/Network/NetworkUtils.h
+++ b/atcg_lib/include/Network/NetworkUtils.h
@@ -59,6 +59,22 @@ ATCG_INLINE std::string readString(uint8_t* data, uint32_t& offset)
 }
 
 /**
+ * @brief Read a struct from a buffer
+ *
+ * @tparam T The struct datatype
+ * @param data The buffer to read from
+ * @param offset The read offset into the buffer. This value gets advanced by the number of read bytes
+ * @return The requested data
+ */
+template<typename T>
+ATCG_INLINE T readStruct(uint8_t* data, uint32_t& offset)
+{
+    T obj = *(T*)(data + offset);
+    offset += sizeof(T);
+    return obj;
+}
+
+/**
  * @brief Write a byte into a data buffer.
  *
  * @param data The data buffer to write to
@@ -118,6 +134,21 @@ ATCG_INLINE void writeBuffer(uint8_t* data, uint32_t& offset, uint8_t* toWrite, 
 ATCG_INLINE void writeString(uint8_t* data, uint32_t& offset, const std::string toWrite)
 {
     writeBuffer(data, offset, (uint8_t*)toWrite.c_str(), toWrite.length());
+}
+
+/**
+ * @brief Write a struct to a buffer
+ *
+ * @tparam T The struct datatype
+ * @param data The buffer to read from
+ * @param offset The read offset into the buffer. This value gets advanced by the number of read bytes
+ * @param toWrite The object to write
+ */
+template<typename T>
+ATCG_INLINE void writeStruct(uint8_t* data, uint32_t& offset, const T& toWrite)
+{
+    std::memcpy(data + offset, (const void*)(&toWrite), sizeof(T));
+    offset += sizeof(T);
 }
 }    // namespace NetworkUtils
 }    // namespace atcg

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -426,6 +426,8 @@ Network
    :project: ATCGLIB
 .. doxygenfunction:: atcg::NetworkUtils::readString
    :project: ATCGLIB
+.. doxygenfunction:: atcg::NetworkUtils::readStruct
+   :project: ATCGLIB
 .. doxygenfunction:: atcg::NetworkUtils::writeByte
    :project: ATCGLIB
 .. doxygenfunction:: atcg::NetworkUtils::writeInt
@@ -433,6 +435,8 @@ Network
 .. doxygenfunction:: atcg::NetworkUtils::writeBuffer
    :project: ATCGLIB
 .. doxygenfunction:: atcg::NetworkUtils::writeString
+   :project: ATCGLIB
+.. doxygenfunction:: atcg::NetworkUtils::writeStruct
    :project: ATCGLIB
 
 OpenMesh


### PR DESCRIPTION
Add functions to read and write simple structs from buffers, e.g. network buffers.