### PR TITLE
Fix crash when using JPEG modules without initializing chached allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed linking of imgui in headless mode by removing unnecessary libraries in linking stage
+- Fixed crash when using the JPEG modules without initializing the torch allocator

--- a/atcg_lib/platform/cuda/src/DataStructure/JPEGDecoder.cpp
+++ b/atcg_lib/platform/cuda/src/DataStructure/JPEGDecoder.cpp
@@ -116,6 +116,11 @@ JPEGDecoder::Impl::Impl(uint32_t num_images,
     this->img_width       = img_width;
     this->img_height      = img_height;
     this->flip_vertically = flip_vertically;
+
+    // This initializes the cache allocator
+    torch::empty({1}, atcg::TensorOptions::floatDeviceOptions());
+    torch::empty({1}, atcg::TensorOptions::floatHostOptions());
+
     allocateBuffers();
     initializeNVJPEG(backend);
 }

--- a/atcg_lib/platform/cuda/src/DataStructure/JPEGEncoder.cpp
+++ b/atcg_lib/platform/cuda/src/DataStructure/JPEGEncoder.cpp
@@ -95,6 +95,11 @@ public:
 JPEGEncoder::Impl::Impl(bool flip_vertically, JPEGBackend backend)
 {
     this->flip_vertically = flip_vertically;
+
+    // This initializes the cache allocator
+    torch::empty({1}, atcg::TensorOptions::floatDeviceOptions());
+    torch::empty({1}, atcg::TensorOptions::floatHostOptions());
+
     allocateBuffers();
     initializeNVJPEG(backend);
 }


### PR DESCRIPTION
JPEGEncoder and JPEGDecoder use the CUDA cache allocator from torch. However, if no tensor was created before instantiating these modules, the allocator is not initialized, leading to a crash. This was fixed by allocating some dummy tensors on creation.