### PR TITLE
Fix use of global renderer instance in screenshot function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Note that this project is currently in a beta state. Therefore, there might be API changes that are not reflected in the versioning.
 
+## [Unreleased]
+
+### Fixed
+
+- Screenshot functionality of Renderer uses correct member method and not global renderer instance.
+
 ## [0.1.1-beta]
 
 ### Added

--- a/atcg_lib/platform/opengl/src/Renderer/Renderer.cpp
+++ b/atcg_lib/platform/opengl/src/Renderer/Renderer.cpp
@@ -24,6 +24,7 @@ public:
 
     atcg::ref_ptr<Context> context;
     atcg::ref_ptr<ShaderManagerSystem> shader_manager;
+    RendererSystem* renderer = nullptr;
 
     atcg::ref_ptr<VertexArray> quad_vao;
     atcg::ref_ptr<VertexBuffer> quad_vbo;
@@ -367,6 +368,8 @@ void RendererSystem::init(uint32_t width,
     impl->shader_manager->addShaderFromName("cubeMapConvolution");
     impl->shader_manager->addShaderFromName("prefilter_cubemap");
     impl->shader_manager->addShaderFromName("vrScreen");
+
+    impl->renderer = this;
 }
 
 void RendererSystem::finishFrame()
@@ -1256,11 +1259,11 @@ void RendererSystem::screenshot(const atcg::ref_ptr<Scene>& scene,
     screenshot_buffer->complete();
 
     screenshot_buffer->use();
-    atcg::RendererSystem::clear();
-    atcg::RendererSystem::setViewport(0, 0, width, height);
-    atcg::RendererSystem::draw(scene, cam);
-    atcg::RendererSystem::getFramebuffer()->use();
-    atcg::RendererSystem::setDefaultViewport();
+    clear();
+    setViewport(0, 0, width, height);
+    draw(scene, cam);
+    getFramebuffer()->use();
+    setDefaultViewport();
 
     auto data = screenshot_buffer->getColorAttachement(0)->getData(atcg::CPU);
 
@@ -1282,11 +1285,11 @@ RendererSystem::screenshot(const atcg::ref_ptr<Scene>& scene, const atcg::ref_pt
     screenshot_buffer->complete();
 
     screenshot_buffer->use();
-    atcg::RendererSystem::clear();
-    atcg::RendererSystem::setViewport(0, 0, width, height);
-    atcg::RendererSystem::draw(scene, cam);
-    atcg::RendererSystem::getFramebuffer()->use();
-    atcg::RendererSystem::setDefaultViewport();
+    clear();
+    setViewport(0, 0, width, height);
+    draw(scene, cam);
+    getFramebuffer()->use();
+    setDefaultViewport();
 
     auto data = screenshot_buffer->getColorAttachement(0)->getData(atcg::CPU);
 


### PR DESCRIPTION
Fix use of global renderer instance in screenshot function. Closing #41 