### PR TITLE
Reset all texture unit bindings at the end of each frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If an Entity can't be found by ID, an invalid entity is returned
 - Circle shader now also writes out entity IDs
 - Removed RendererSystem::draw function that takes in a material struct
+- At the end of each frame, all texture units are unbinded to create a clean state for the next frame
 
 ### Fixed
 
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix normals of cylinder in test scene
 - Normals of cylinder in test scene
 - Improved code of the Renderer and reduced code duplication
+- Fixed hanging texture references when a texture is deleted
 
 ## [0.1.1-beta]
 

--- a/atcg_lib/platform/opengl/src/Renderer/Renderer.cpp
+++ b/atcg_lib/platform/opengl/src/Renderer/Renderer.cpp
@@ -951,6 +951,20 @@ void RendererSystem::finishFrame()
     glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(ibo->getCount()), GL_UNSIGNED_INT, (void*)0);
 #endif
     ++impl->frame_counter;
+
+    GLint maxTextureUnits;
+    glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &maxTextureUnits);
+
+    for(int i = 0; i < maxTextureUnits; ++i)
+    {
+        glActiveTexture(GL_TEXTURE0 + i);
+        glBindTexture(GL_TEXTURE_2D, 0);
+        glBindTexture(GL_TEXTURE_3D, 0);
+        glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+        glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
+        glBindTexture(GL_TEXTURE_CUBE_MAP_ARRAY, 0);
+    }
+    glActiveTexture(GL_TEXTURE0);
 }
 
 void RendererSystem::setClearColor(const glm::vec4& color)


### PR DESCRIPTION
If a texture is deleted but still bound to a texture slot, it can create undefined behavior or errors in the OpenGL pipeline. Therefore, we now reset all texture bindings at the end of each frame