### PR TITLE
Fix crash when a script is still active in the revision system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added method to update the near and far plane of the VR System
 
+### Fixed
+
+- Fixed crash when a Script is held inside the revision system and the app is closed
+
 ## [0.2.1-beta]
 
 ### Fixed

--- a/atcg_lib/src/Core/Application.cpp
+++ b/atcg_lib/src/Core/Application.cpp
@@ -24,6 +24,7 @@ Application::Application(const WindowProps& props)
 
 Application::~Application()
 {
+    _revision_system->clearChache();
     if(_script_engine) _script_engine->destroy();
 }
 


### PR DESCRIPTION
The Revisionstack was destroyed after the scripting engine was shut down. This lead to a crash when there are scripts still instantiated inside the revision system and we try to free them without valid python context. This is fixed by clearing the cache of the revision system before destroying the scripting engine.