### PR TITLE
Change design of component serializer via template specialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed atcg::Instance
 - InstanceRenderComponents now longer are hard typed to atcg::Instance but can be filled with an arbitrary number of instance buffers
+- Renamed Serializer to SceneSerializer
+- Instead of having one class that handles serialization of all components, the design was changed to have individual ComponentSerializer structs that can be implemented via template specialization.
 
 ### Fixed
 

--- a/atcg_lib/include/Scene/ComponentSerializer.h
+++ b/atcg_lib/include/Scene/ComponentSerializer.h
@@ -7,90 +7,178 @@
 
 namespace atcg
 {
+namespace Serialization
+{
 /**
  * @brief A class that handles the serialization of components
  *
- * To add custom serialization code, create a class that inherits from this class and add the serialization code for the
- * custom component. To get the default behavior, override the serialize_component and deserialize_component function
- * that calls the super class. Add this class as template argument to the atcg::Serializer.
+ * @tparam T The component to serialize
+ *
+ * To add custom serialization code, create a template specialization that implements the serialize_component and
+ * deserialize_component function.
  *
  * @code{.cpp}
- * class MyComponentSerializer : ComponentSerializer
+ * template<>
+ * struct atcg::Serialization::ComponentSerializer<CustomComponent>
  * {
- * public:
- *      MyComponentSerializer(atcg::ref_ptr<Scene>& scene) :ComponentSerializer(scene) {}
- *
- *      template<typename T>
- *      void serialize_component(const std::string& file_path, Entity entity, T& component, nlohmann::json& j)
- *      {
- *          ComponentSerializer::serialize_component<T>(file_path, entity, component, j);
- *      }
- *
- *      template<>
- *      void serialize_component<MyCustomComponent>(const std::string& file_path,
- *                                             Entity entity, T& component,
- *                                             nlohmann::json& j)
- *      {
- *          // Serialize custom component
- *      }
- *
- *      template<typename T>
- *      void deserialize_component(const std::string& file_path, Entity entity, nlohmann::json& j)
- *      {
- *          ComponentSerializer::deserialize_component<T>(file_path, entity, j);
- *      }
- *
- *      template<>
- *      void deserialize_component<MyCustomComponent>(const std::string& file_path, Entity entity, nlohmann::json& j)
- *      {
- *          // Serialize custom component
- *      }
+ *     void serialize_component(const std::string& file_path,
+ *                              const atcg::ref_ptr<Scene>& scene,
+ *                              Entity entity,
+ *                              CustomComponent& component,
+ *                              nlohmann::json& j) const
+ *     {
+ *         j["CustomComponent"]["Content"] = component.content;
+ *     }
+
+ *     void deserialize_component(const std::string& file_path,
+ *                              const atcg::ref_ptr<Scene>& scene,
+ *                              Entity entity,
+ *                              nlohmann::json& j) const
+ *     {
+ *         if(!j.contains("CustomComponent"))
+ *         {
+ *             return;
+ *         }
+
+ *         auto& component   = entity.addComponent<CustomComponent>();
+ *         component.content = j["CustomComponent"]["Content"];
+ *     }
  * };
  * @endcode
  */
-class ComponentSerializer
+template<typename T>
+struct ComponentSerializer
 {
-public:
-    /**
-     * @brief Constructor
-     *
-     * @param scene The scene
-     */
-    ComponentSerializer(const atcg::ref_ptr<Scene>& scene) : _scene(scene) {}
-
     /**
      * @brief Serialize a component
      *
-     * @tparam T The component type
-     *
-     * @param file_path The file path of the serialized file
-     * @param entity The serialized entity
+     * @param file_path The file_path of the serialized scene. This can be used to store additional buffers in the same
+     * directory
+     * @param scene The scene to which the entity holding the component belongs to
+     * @param entity The entity that holds the component
      * @param component The component to serialize
-     * @param j The json representing the serialized entity
+     * @param j The json object
      */
-    template<typename T>
-    void serialize_component(const std::string& file_path, Entity entity, T& component, nlohmann::json& j);
+    void serialize_component(const std::string& file_path,
+                             const atcg::ref_ptr<Scene>& scene,
+                             Entity entity,
+                             T& component,
+                             nlohmann::json& j) const
+    {
+        throw std::logic_error("No ComponentSerializer specialization available for this component type");
+    }
 
     /**
      * @brief Deserialize a component
      *
-     * @tparam T The component type
-     *
-     * @param file_path The file path of the serialized file
-     * @param entity The deserialized entity
-     * @param j The json representing the serialized entity
+     * @param file_path The file_path of the serialized scene. This can be used to store additional buffers in the same
+     * directory
+     * @param scene The scene to which the entity holding the component belongs to
+     * @param entity The entity that holds the component
+     * @param j The json object
      */
-    template<typename T>
-    void deserialize_component(const std::string& file_path, Entity entity, nlohmann::json& j);
-
-protected:
-    void serializeBuffer(const std::string& file_name, const char* data, const uint32_t byte_size);
-    std::vector<uint8_t> deserializeBuffer(const std::string& file_name);
-    void serializeMaterial(nlohmann::json& out, Entity entity, const Material& material, const std::string& file_path);
-    Material deserialize_material(const nlohmann::json& material_node);
-    void serializeTexture(const atcg::ref_ptr<Texture2D>& texture, std::string& path, float gamma = 1.0f);
-    nlohmann::json serializeLayout(const atcg::BufferLayout& layout);
-    atcg::BufferLayout deserializeLayout(nlohmann::json& layout_node);
-    atcg::ref_ptr<Scene> _scene;
+    void deserialize_component(const std::string& file_path,
+                               const atcg::ref_ptr<Scene>& scene,
+                               Entity entity,
+                               nlohmann::json& j) const
+    {
+        throw std::logic_error("No ComponentSerializer specialization available for this component type");
+    }
 };
+
+#define ATCG_DECLARE_COMPONENT_SERIALIZER(ComponentType)                                                               \
+    template<>                                                                                                         \
+    struct ComponentSerializer<ComponentType>                                                                          \
+    {                                                                                                                  \
+        void serialize_component(const std::string& file_path,                                                         \
+                                 const atcg::ref_ptr<Scene>& scene,                                                    \
+                                 Entity entity,                                                                        \
+                                 ComponentType& component,                                                             \
+                                 nlohmann::json& j) const;                                                             \
+                                                                                                                       \
+        void deserialize_component(const std::string& file_path,                                                       \
+                                   const atcg::ref_ptr<Scene>& scene,                                                  \
+                                   Entity entity,                                                                      \
+                                   nlohmann::json& j) const;                                                           \
+    }
+
+ATCG_DECLARE_COMPONENT_SERIALIZER(IDComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(NameComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(TransformComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(CameraComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(GeometryComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(MeshRenderComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(PointRenderComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(PointSphereRenderComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(EdgeRenderComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(EdgeCylinderRenderComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(InstanceRenderComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(PointLightComponent);
+ATCG_DECLARE_COMPONENT_SERIALIZER(ScriptComponent);
+
+/**
+ * @brief Serialize a buffer
+ *
+ * @param file_name The file name
+ * @param data The buffer data
+ * @param byte_size The buffer size in bytes
+ */
+void serializeBuffer(const std::string& file_name, const char* data, const uint32_t byte_size);
+
+/**
+ * @brief Deserialize a buffer
+ *
+ * @param file_name The file name
+ *
+ * @return The deserialized data
+ */
+std::vector<uint8_t> deserializeBuffer(const std::string& file_name);
+
+/**
+ * @brief Serialize a material.
+ * Images are serialized into: file_path + "_" + std::to_string(entity_id) + "_<texture_type>"
+ *
+ * @param out The json node where the material should be serialized
+ * @param entity The entity which this material belongs to
+ * @param material The material
+ * @param file_path The file path
+ */
+void serializeMaterial(nlohmann::json& out, Entity entity, const Material& material, const std::string& file_path);
+
+/**
+ * @brief Deserialize the material
+ *
+ * @param material_node The node containing the material
+ *
+ * @return The material
+ */
+Material deserialize_material(const nlohmann::json& material_node);
+
+/**
+ * @brief Serialize a texture
+ *
+ * @param texture The texture to serialize
+ * @param path The file path
+ * @param gamma A gamma value that should be applied
+ */
+void serializeTexture(const atcg::ref_ptr<Texture2D>& texture, std::string& path, float gamma = 1.0f);
+
+/**
+ * @brief Serialize a layout
+ *
+ * @param layout The buffer layout
+ *
+ * @return The json object representing the layout
+ */
+nlohmann::json serializeLayout(const atcg::BufferLayout& layout);
+
+/**
+ * @brief Deserialize a layout
+ *
+ * @param layout_node The json node containing the Layout data
+ *
+ * @return The BufferLayout
+ */
+atcg::BufferLayout deserializeLayout(nlohmann::json& layout_node);
+}    // namespace Serialization
 }    // namespace atcg

--- a/atcg_lib/include/Scene/Serializer.h
+++ b/atcg_lib/include/Scene/Serializer.h
@@ -3,20 +3,18 @@
 #include <Core/Memory.h>
 #include <Scene/Entity.h>
 
-#include <Scene/ComponentSerializer.h>
-
 #include <json.hpp>
 
 namespace atcg
 {
 
+namespace Serialization
+{
+
 /**
  * @brief A class that handles scene serialization
- *
- * @tparam ComponentSerializerT The class that handles serialization of individual components
  */
-template<typename ComponentSerializerT = ComponentSerializer>
-class Serializer
+class SceneSerializer
 {
 public:
     /**
@@ -25,7 +23,7 @@ public:
      *
      * @param scene The scene.
      */
-    Serializer(const atcg::ref_ptr<Scene>& scene);
+    SceneSerializer(const atcg::ref_ptr<Scene>& scene);
 
     /**
      * @brief Serialize the scene.
@@ -58,8 +56,8 @@ private:
     void deserializeEntity(const std::string& file_path, Entity entity, nlohmann::json& entity_object);
 
     atcg::ref_ptr<Scene> _scene;
-    atcg::ref_ptr<ComponentSerializerT> _component_serializer;
 };
+}    // namespace Serialization
 }    // namespace atcg
 
 #include "../../src/Scene/SerializerDetail.h"

--- a/atcg_lib/platform/python/pyatcg.h
+++ b/atcg_lib/platform/python/pyatcg.h
@@ -127,7 +127,7 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, atcg::ref_ptr<T>);
     auto m_vertex_specification  = py::class_<atcg::VertexSpecification>(m, "VertexSpecification");                             \
     auto m_edge_specification    = py::class_<atcg::EdgeSpecification>(m, "EdgeSpecification");                                 \
     auto m_graph                 = py::class_<atcg::Graph, atcg::ref_ptr<atcg::Graph>>(m, "Graph");                             \
-    auto m_serializer            = py::class_<atcg::Serializer<atcg::ComponentSerializer>>(m, "Serializer");                    \
+    auto m_serializer            = py::class_<atcg::Serialization::SceneSerializer>(m, "SceneSerializer");                      \
     auto m_renderer              = m.def_submodule("Renderer");                                                                 \
     auto m_renderer_system =                                                                                                    \
         py::class_<atcg::RendererSystem, atcg::ref_ptr<atcg::RendererSystem>>(m, "RendererSystem");                             \
@@ -631,8 +631,8 @@ inline void defineBindings(py::module_& m)
         .def("getCamera", &atcg::FirstPersonController::getCamera);
 
     m_serializer.def(py::init<const atcg::ref_ptr<atcg::Scene>&>(), "scene"_a)
-        .def("serialize", &atcg::Serializer<atcg::ComponentSerializer>::serialize<>, "file_path"_a)
-        .def("deserialize", &atcg::Serializer<atcg::ComponentSerializer>::deserialize<>, "file_path"_a);
+        .def("serialize", &atcg::Serialization::SceneSerializer::serialize<>, "file_path"_a)
+        .def("deserialize", &atcg::Serialization::SceneSerializer::deserialize<>, "file_path"_a);
 
     m_performance_panel.def(py::init<>())
         .def(

--- a/docs/source/DataStructure/Graph.rst
+++ b/docs/source/DataStructure/Graph.rst
@@ -15,9 +15,6 @@ Graph
 .. doxygenstruct:: atcg::EdgeSpecification
    :members:
    :undoc-members:
-.. doxygenstruct:: atcg::Instance
-   :members:
-   :undoc-members:
 .. doxygenclass:: atcg::Graph
    :members:
    :undoc-members:

--- a/docs/source/Scene/Serializer.rst
+++ b/docs/source/Scene/Serializer.rst
@@ -1,9 +1,23 @@
 Serializer
 ==========
 
-.. doxygenclass:: atcg::Serializer
+.. doxygenclass:: atcg::Serialization::SceneSerializer
    :members:
    :undoc-members:
-.. doxygenclass:: atcg::ComponentSerializer
+.. doxygenstruct:: atcg::Serialization::ComponentSerializer
    :members:
    :undoc-members:
+.. doxygenfunction:: atcg::Serialization::serializeBuffer
+   :project: ATCGLIB
+.. doxygenfunction:: atcg::Serialization::deserializeBuffer
+   :project: ATCGLIB
+.. doxygenfunction:: atcg::Serialization::serializeMaterial
+   :project: ATCGLIB
+.. doxygenfunction:: atcg::Serialization::deserialize_material
+   :project: ATCGLIB
+.. doxygenfunction:: atcg::Serialization::serializeTexture
+   :project: ATCGLIB
+.. doxygenfunction:: atcg::Serialization::serializeLayout
+   :project: ATCGLIB
+.. doxygenfunction:: atcg::Serialization::deserializeLayout
+   :project: ATCGLIB

--- a/src/Cloth/source.cpp
+++ b/src/Cloth/source.cpp
@@ -136,14 +136,14 @@ public:
         {
             if(ImGui::MenuItem("Save"))
             {
-                atcg::Serializer<atcg::ComponentSerializer> serializer(scene);
+                atcg::Serialization::SceneSerializer serializer(scene);
                 serializer.serialize((atcg::resource_directory() / "Cloth/Scene.yaml").string());
             }
 
             if(ImGui::MenuItem("Load"))
             {
                 scene = atcg::make_ref<atcg::Scene>();
-                atcg::Serializer<atcg::ComponentSerializer> serializer(scene);
+                atcg::Serialization::SceneSerializer serializer(scene);
                 serializer.deserialize((atcg::resource_directory() / "Cloth/Scene.yaml").string());
 
                 auto entities     = scene->getEntitiesByName("EditorCamera");

--- a/src/Deferred/source.cpp
+++ b/src/Deferred/source.cpp
@@ -372,7 +372,7 @@ public:
         {
             if(ImGui::MenuItem("Save"))
             {
-                atcg::Serializer<atcg::ComponentSerializer> serializer(scene);
+                atcg::Serialization::SceneSerializer serializer(scene);
 
                 serializer.serialize("../Scene/Scene.json");
             }
@@ -380,7 +380,7 @@ public:
             if(ImGui::MenuItem("Load"))
             {
                 scene->removeAllEntites();
-                atcg::Serializer<atcg::ComponentSerializer> serializer(scene);
+                atcg::Serialization::SceneSerializer serializer(scene);
 
                 serializer.deserialize("../Scene/Scene.json");
 

--- a/src/PBR/source.cpp
+++ b/src/PBR/source.cpp
@@ -187,7 +187,7 @@ public:
         {
             if(ImGui::MenuItem("Save"))
             {
-                atcg::Serializer<atcg::ComponentSerializer> serializer(scene);
+                atcg::Serialization::SceneSerializer serializer(scene);
 
                 serializer.serialize("../Scene/Scene.json");
             }
@@ -195,7 +195,7 @@ public:
             if(ImGui::MenuItem("Load"))
             {
                 scene->removeAllEntites();
-                atcg::Serializer<atcg::ComponentSerializer> serializer(scene);
+                atcg::Serialization::SceneSerializer serializer(scene);
 
                 serializer.deserialize("../Scene/Scene.json");
 


### PR DESCRIPTION
Previously, the ComponentSerializer was one class responsible for serialization of all components. This was changed in this update to have one templated struct that handles serialization of one component. This makes adding custom components easier.