### PR TITLE
Change rendering of component GUIs to template specialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed atcg::Instance
 - InstanceRenderComponents now longer are hard typed to atcg::Instance but can be filled with an arbitrary number of instance buffers
+- Moved Serialization code to Serialization namespace
 - Renamed Serializer to SceneSerializer
 - Instead of having one class that handles serialization of all components, the design was changed to have individual ComponentSerializer structs that can be implemented via template specialization.
+- The same thing is done for the GUI rendering of components
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed Serializer to SceneSerializer
 - Instead of having one class that handles serialization of all components, the design was changed to have individual ComponentSerializer structs that can be implemented via template specialization.
 - The same thing is done for the GUI rendering of components
+- Moved SceneHierarchyPanel and PerformancePanel to GUI namespace
 
 ### Fixed
 

--- a/atcg_lib/include/DataStructure/PerformancePanel.h
+++ b/atcg_lib/include/DataStructure/PerformancePanel.h
@@ -5,6 +5,8 @@
 namespace atcg
 {
 
+namespace GUI
+{
 /**
  * @brief A debug panel to display frame times
  */
@@ -39,4 +41,5 @@ private:
         atcg::CyclicCollection<float>("Frame Time Collection", 5);
     uint32_t _frame_id = 0;
 };
+}    // namespace GUI
 }    // namespace atcg

--- a/atcg_lib/include/Scene/ComponentGUIHandler.h
+++ b/atcg_lib/include/Scene/ComponentGUIHandler.h
@@ -7,60 +7,69 @@
 
 namespace atcg
 {
+namespace GUI
+{
+
 /**
  * @brief A class that handles the rendering of gui components
  *
- * To add custom rendering code, create a class that inherits from this class and add the rendering code for the custom
- * component. To get the default behavior, override the draw_component function that calls the super class. Add this
- * class as template argument to the atcg::SceneHierarchyPanel.
- *
- * @note The code below is an example for MSVC. Under different compilers, one might have to restructure the template
- * specialization.
+ * To add custom rendering code, create a class that specializes this class and add the rendering code for the custom
+ * component.
  *
  * @code{.cpp}
- * class MyComponentGUIHandler : public ComponentGUIHandler
+ * template<>
+ * struct atcg::GUI::ComponentGUIRenderer<CustomComponent>
  * {
- * public:
- *      MyComponentGUIHandler(const atcg::ref_ptr<Scene>& scene) :ComponentGUIHandler(scene) {}
- *
- *      template<typename T>
- *      void draw_component(Entity entity, T& component)
- *      {
- *          atcg::ComponentGUIHandler::draw_component<T>(entity, component);
- *      }
- *
- *      template<>
- *      void draw_component<MyCustomComponent>(Entity entity, MyCustomComponent& component)
- *      {
- *          // Draw custom component
- *      }
+ *     void draw_component(const atcg::ref_ptr<Scene>& scene, Entity entity, CustomComponent& component) const
+ *     {
+ *         // Render Code
+ *     }
  * };
  * @endcode
  */
-class ComponentGUIHandler
+template<typename T>
+struct ComponentGUIRenderer
 {
-public:
     /**
-     * @brief Constructor
+     * @brief Draw the component
      *
-     * @param scene The scene
+     * @param scene The scene the entity belongs to
+     * @param entity The entity that holds the component
+     * @param component The component to render
      */
-    ComponentGUIHandler(const atcg::ref_ptr<Scene>& scene) : _scene(scene) {}
-
-    /**
-     * @brief Draw a component
-     *
-     * @tparam T The component type
-     *
-     * @param entity The entity that owns the component
-     * @param component The component
-     */
-    template<typename T>
-    void draw_component(Entity entity, T& component);
-
-protected:
-    bool displayMaterial(const std::string& key, Material& material);
-
-    atcg::ref_ptr<Scene> _scene;
+    void draw_component(const atcg::ref_ptr<Scene>& scene, Entity entity, T& component) const
+    {
+        throw std::logic_error("No ComponentGUIRenderer specialization available for this component type");
+    }
 };
+
+#define ATCG_DECLARE_COMPONENT_GUI_RENDERER(ComponentType)                                                             \
+    template<>                                                                                                         \
+    struct ComponentGUIRenderer<ComponentType>                                                                         \
+    {                                                                                                                  \
+        void draw_component(const atcg::ref_ptr<Scene>& scene, Entity entity, ComponentType& component) const;         \
+    }
+
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(TransformComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(CameraComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(GeometryComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(MeshRenderComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(PointRenderComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(PointSphereRenderComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(EdgeRenderComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(EdgeCylinderRenderComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(InstanceRenderComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(PointLightComponent);
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(ScriptComponent);
+
+/**
+ * @brief Display a material
+ *
+ * @param key The imgui key
+ * @param material The material
+ *
+ * @return true if the material has been updated this frame
+ */
+bool displayMaterial(const std::string& key, Material& material);
+}    // namespace GUI
 }    // namespace atcg

--- a/atcg_lib/include/Scene/SceneHierarchyPanel.h
+++ b/atcg_lib/include/Scene/SceneHierarchyPanel.h
@@ -10,12 +10,11 @@ namespace atcg
 class Scene;
 class Framebuffer;
 
+namespace GUI
+{
 /**
  * @brief A Scene hierarchy panel
- *
- * @tparam GUIHandler The class that handles gui drawing. Default = atcg::ComponentGUIHandler
  */
-template<typename GUIHandler = ComponentGUIHandler>
 class SceneHierarchyPanel
 {
 public:
@@ -56,13 +55,6 @@ public:
      */
     ATCG_INLINE Entity getSelectedEntity() const { return _selected_entity; }
 
-    /**
-     * @brief Set a custom gui handler
-     *
-     * @param gui_handler The gui handler instance
-     */
-    ATCG_INLINE void setGuiHandler(const atcg::ref_ptr<GUIHandler>& gui_handler) { _gui_handler = gui_handler; }
-
 private:
     void drawEntityNode(Entity entity);
 
@@ -72,10 +64,10 @@ private:
     void drawSceneProperties();
     Entity _selected_entity;
     atcg::ref_ptr<Scene> _scene;
-    atcg::ref_ptr<GUIHandler> _gui_handler;
 
     bool _focues_components = false;
 };
+}    // namespace GUI
 }    // namespace atcg
 
 #ifndef ATCG_HEADLESS

--- a/atcg_lib/platform/glfw/src/Scene/SceneHierarchyPanelDetails.h
+++ b/atcg_lib/platform/glfw/src/Scene/SceneHierarchyPanelDetails.h
@@ -7,12 +7,12 @@
 
 namespace atcg
 {
-
+namespace GUI
+{
 namespace detail
 {
-template<typename GUIHandler, typename T>
-ATCG_INLINE void
-drawComponent(const atcg::ref_ptr<Scene>& scene, Entity entity, const atcg::ref_ptr<GUIHandler>& gui_handler)
+template<typename T>
+ATCG_INLINE void drawComponent(const atcg::ref_ptr<Scene>& scene, Entity entity)
 {
     const ImGuiTreeNodeFlags treeNodeFlags = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed |
                                              ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_AllowItemOverlap |
@@ -40,7 +40,7 @@ drawComponent(const atcg::ref_ptr<Scene>& scene, Entity entity, const atcg::ref_
 
         if(open)
         {
-            gui_handler->template draw_component<T>(entity, component);
+            ComponentGUIRenderer<T>().draw_component(scene, entity, component);
             ImGui::TreePop();
         }
 
@@ -91,15 +91,9 @@ ATCG_INLINE void displayAddComponentEntry<CameraComponent>(const atcg::ref_ptr<a
 
 }    // namespace detail
 
-template<typename GUIHandler>
-SceneHierarchyPanel<GUIHandler>::SceneHierarchyPanel(const atcg::ref_ptr<Scene>& scene)
-    : _scene(scene),
-      _gui_handler(atcg::make_ref<GUIHandler>(scene))
-{
-}
+ATCG_INLINE SceneHierarchyPanel::SceneHierarchyPanel(const atcg::ref_ptr<Scene>& scene) : _scene(scene) {}
 
-template<typename GUIHandler>
-void SceneHierarchyPanel<GUIHandler>::drawEntityNode(Entity entity)
+ATCG_INLINE void SceneHierarchyPanel::drawEntityNode(Entity entity)
 {
     auto& tag = entity.getComponent<NameComponent>().name();
 
@@ -137,8 +131,7 @@ void SceneHierarchyPanel<GUIHandler>::drawEntityNode(Entity entity)
     }
 }
 
-template<typename GUIHandler>
-void SceneHierarchyPanel<GUIHandler>::drawSceneProperties()
+ATCG_INLINE void SceneHierarchyPanel::drawSceneProperties()
 {
     float content_scale                    = atcg::Application::get()->getWindow()->getContentScale();
     const ImGuiTreeNodeFlags treeNodeFlags = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed |
@@ -294,9 +287,8 @@ void SceneHierarchyPanel<GUIHandler>::drawSceneProperties()
     }
 }
 
-template<typename GUIHandler>
 template<typename... Components>
-ATCG_INLINE void SceneHierarchyPanel<GUIHandler>::drawComponents(Entity entity)
+ATCG_INLINE void SceneHierarchyPanel::drawComponents(Entity entity)
 {
     std::string id = std::to_string(entity.getComponent<IDComponent>().ID());
     std::stringstream label;
@@ -334,19 +326,17 @@ ATCG_INLINE void SceneHierarchyPanel<GUIHandler>::drawComponents(Entity entity)
 
     ImGui::PopItemWidth();
 
-    (detail::drawComponent<GUIHandler, Components>(_scene, entity, _gui_handler), ...);
+    (detail::drawComponent<Components>(_scene, entity), ...);
 }
 
-template<typename GUIHandler>
-ATCG_INLINE void SceneHierarchyPanel<GUIHandler>::selectEntity(Entity entity)
+ATCG_INLINE void SceneHierarchyPanel::selectEntity(Entity entity)
 {
     _selected_entity   = entity;
     _focues_components = true;
 }
 
-template<typename GUIHandler>
 template<typename... CustomComponents>
-ATCG_INLINE void SceneHierarchyPanel<GUIHandler>::renderPanel()
+ATCG_INLINE void SceneHierarchyPanel::renderPanel()
 {
     ImGui::Begin("Scene Hierarchy");
 
@@ -420,4 +410,5 @@ ATCG_INLINE void SceneHierarchyPanel<GUIHandler>::renderPanel()
 
     ImGui::End();
 }
+}    // namespace GUI
 }    // namespace atcg

--- a/atcg_lib/platform/headless/src/Scene/ComponentGUIHandler.cpp
+++ b/atcg_lib/platform/headless/src/Scene/ComponentGUIHandler.cpp
@@ -2,67 +2,90 @@
 
 namespace atcg
 {
-template<typename T>
-void ComponentGUIHandler::draw_component(Entity entity, T& component)
+namespace GUI
+{
+
+
+void ComponentGUIRenderer<TransformComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                              Entity entity,
+                                                              TransformComponent& transform) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<TransformComponent>(Entity entity, TransformComponent& transform)
+
+void ComponentGUIRenderer<CameraComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                           Entity entity,
+                                                           CameraComponent& camera_component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<CameraComponent>(Entity entity, CameraComponent& camera_component)
+
+void ComponentGUIRenderer<GeometryComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                             Entity entity,
+                                                             GeometryComponent& component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<GeometryComponent>(Entity entity, GeometryComponent& component)
+
+void ComponentGUIRenderer<MeshRenderComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                               Entity entity,
+                                                               MeshRenderComponent& component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<MeshRenderComponent>(Entity entity, MeshRenderComponent& component)
+
+void ComponentGUIRenderer<PointRenderComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                                Entity entity,
+                                                                PointRenderComponent& component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<PointRenderComponent>(Entity entity, PointRenderComponent& component)
+
+void ComponentGUIRenderer<PointSphereRenderComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                                      Entity entity,
+                                                                      PointSphereRenderComponent& component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<PointSphereRenderComponent>(Entity entity,
-                                                                     PointSphereRenderComponent& component)
+
+void ComponentGUIRenderer<EdgeRenderComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                               Entity entity,
+                                                               EdgeRenderComponent& component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<EdgeRenderComponent>(Entity entity, EdgeRenderComponent& component)
+
+void ComponentGUIRenderer<EdgeCylinderRenderComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                                       Entity entity,
+                                                                       EdgeCylinderRenderComponent& component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<EdgeCylinderRenderComponent>(Entity entity,
-                                                                      EdgeCylinderRenderComponent& component)
+
+void ComponentGUIRenderer<InstanceRenderComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                                   Entity entity,
+                                                                   InstanceRenderComponent& component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<InstanceRenderComponent>(Entity entity, InstanceRenderComponent& component)
+
+void ComponentGUIRenderer<PointLightComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                               Entity entity,
+                                                               PointLightComponent& component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<PointLightComponent>(Entity entity, PointLightComponent& component)
+
+void ComponentGUIRenderer<ScriptComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                           Entity entity,
+                                                           ScriptComponent& _component) const
 {
 }
 
-template<>
-void ComponentGUIHandler::draw_component<ScriptComponent>(Entity entity, ScriptComponent& _component)
+bool displayMaterial(const std::string& key, Material& material)
 {
+    return false;
 }
 
-bool ComponentGUIHandler::displayMaterial(const std::string& key, Material& material) {}
+}    // namespace GUI
 }    // namespace atcg

--- a/atcg_lib/platform/headless/src/Scene/SceneHierarchyPanelDetails.h
+++ b/atcg_lib/platform/headless/src/Scene/SceneHierarchyPanelDetails.h
@@ -2,40 +2,28 @@
 
 namespace atcg
 {
-
-template<typename GUIHandler>
-SceneHierarchyPanel<GUIHandler>::SceneHierarchyPanel(const atcg::ref_ptr<Scene>& scene)
-    : _scene(scene),
-      _gui_handler(atcg::make_ref<GUIHandler>(scene))
+namespace GUI
 {
-}
+ATCG_INLINE SceneHierarchyPanel::SceneHierarchyPanel(const atcg::ref_ptr<Scene>& scene) : _scene(scene) {}
 
-template<typename GUIHandler>
-void SceneHierarchyPanel<GUIHandler>::drawEntityNode(Entity entity)
-{
-}
+ATCG_INLINE void SceneHierarchyPanel::drawEntityNode(Entity entity) {}
 
-template<typename GUIHandler>
-void SceneHierarchyPanel<GUIHandler>::drawSceneProperties()
-{
-}
+ATCG_INLINE void SceneHierarchyPanel::drawSceneProperties() {}
 
-template<typename GUIHandler>
 template<typename... Components>
-ATCG_INLINE void SceneHierarchyPanel<GUIHandler>::drawComponents(Entity entity)
+ATCG_INLINE void SceneHierarchyPanel::drawComponents(Entity entity)
 {
 }
 
-template<typename GUIHandler>
-ATCG_INLINE void SceneHierarchyPanel<GUIHandler>::selectEntity(Entity entity)
+ATCG_INLINE void SceneHierarchyPanel::selectEntity(Entity entity)
 {
     _selected_entity   = entity;
     _focues_components = true;
 }
 
-template<typename GUIHandler>
 template<typename... CustomComponents>
-ATCG_INLINE void SceneHierarchyPanel<GUIHandler>::renderPanel()
+ATCG_INLINE void SceneHierarchyPanel::renderPanel()
 {
 }
+}    // namespace GUI
 }    // namespace atcg

--- a/atcg_lib/platform/python/pyatcg.h
+++ b/atcg_lib/platform/python/pyatcg.h
@@ -169,7 +169,7 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, atcg::ref_ptr<T>);
     auto m_network               = m.def_submodule("Network");                                                                  \
     auto m_tcp_server            = py::class_<atcg::TCPServer>(m_network, "TCPServer");                                         \
     auto m_tcp_client            = py::class_<atcg::TCPClient>(m_network, "TCPClient");                                         \
-    auto m_performance_panel     = py::class_<atcg::PerformancePanel>(m, "PerformancePanel");                                   \
+    auto m_performance_panel     = py::class_<atcg::GUI::PerformancePanel>(m, "PerformancePanel");                              \
     auto m_scriptengine =                                                                                                       \
         py::class_<atcg::PythonScriptEngine, atcg::ref_ptr<atcg::PythonScriptEngine>>(m, "ScriptEngine");                       \
     auto m_script = py::class_<atcg::PythonScript, atcg::ref_ptr<atcg::PythonScript>>(m, "Script");
@@ -636,13 +636,13 @@ inline void defineBindings(py::module_& m)
     m_performance_panel.def(py::init<>())
         .def(
             "renderPanel",
-            [](atcg::PerformancePanel& panel, bool show_window)
+            [](atcg::GUI::PerformancePanel& panel, bool show_window)
             {
                 panel.renderPanel(show_window);
                 return show_window;
             },
             "show_window"_a)
-        .def("registerFrameTime", &atcg::PerformancePanel::registerFrameTime);
+        .def("registerFrameTime", &atcg::GUI::PerformancePanel::registerFrameTime);
 
     // ------------------- RENDERER ---------------------------------
     m_draw_mode.value("ATCG_DRAW_MODE_TRIANGLE", atcg::DrawMode::ATCG_DRAW_MODE_TRIANGLE)

--- a/atcg_lib/platform/python/pyatcg.h
+++ b/atcg_lib/platform/python/pyatcg.h
@@ -154,23 +154,22 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, atcg::ref_ptr<T>);
     auto m_edge_renderer          = py::class_<atcg::EdgeRenderComponent>(m, "EdgeRenderComponent");                            \
     auto m_edge_cylinder_renderer = py::class_<atcg::EdgeCylinderRenderComponent>(m, "EdgeCylinderRenderComponent");            \
     auto m_instance_renderer      = py::class_<atcg::InstanceRenderComponent>(m, "InstanceRenderComponent");                    \
-    auto m_vertex_buffer    = py::class_<atcg::VertexBuffer, atcg::ref_ptr<atcg::VertexBuffer>>(m, "VertexBuffer");             \
-    auto m_buffer_layout    = py::class_<atcg::BufferLayout>(m, "BufferLayout");                                                \
-    auto m_buffer_element   = py::class_<atcg::BufferElement>(m, "BufferElement");                                              \
-    auto m_shader_data_type = py::enum_<atcg::ShaderDataType>(m, "ShaderDataType");                                             \
-    auto m_name             = py::class_<atcg::NameComponent>(m, "NameComponent");                                              \
-    auto m_point_light      = py::class_<atcg::PointLightComponent>(m, "PointLightComponent");                                  \
-    auto m_script_component = py::class_<atcg::ScriptComponent>(m, "ScriptComponent");                                          \
-    auto m_scene_hierarchy_panel =                                                                                              \
-        py::class_<atcg::SceneHierarchyPanel<atcg::ComponentGUIHandler>>(m, "SceneHierarchyPanel");                             \
-    auto m_hit_info          = py::class_<atcg::Tracing::HitInfo>(m, "HitInfo");                                                \
-    auto m_utils             = m.def_submodule("Utils");                                                                        \
-    auto m_draw_mode         = py::enum_<atcg::DrawMode>(m, "DrawMode");                                                        \
-    auto m_cull_mode         = py::enum_<atcg::CullMode>(m, "CullMode");                                                        \
-    auto m_network           = m.def_submodule("Network");                                                                      \
-    auto m_tcp_server        = py::class_<atcg::TCPServer>(m_network, "TCPServer");                                             \
-    auto m_tcp_client        = py::class_<atcg::TCPClient>(m_network, "TCPClient");                                             \
-    auto m_performance_panel = py::class_<atcg::PerformancePanel>(m, "PerformancePanel");                                       \
+    auto m_vertex_buffer         = py::class_<atcg::VertexBuffer, atcg::ref_ptr<atcg::VertexBuffer>>(m, "VertexBuffer");        \
+    auto m_buffer_layout         = py::class_<atcg::BufferLayout>(m, "BufferLayout");                                           \
+    auto m_buffer_element        = py::class_<atcg::BufferElement>(m, "BufferElement");                                         \
+    auto m_shader_data_type      = py::enum_<atcg::ShaderDataType>(m, "ShaderDataType");                                        \
+    auto m_name                  = py::class_<atcg::NameComponent>(m, "NameComponent");                                         \
+    auto m_point_light           = py::class_<atcg::PointLightComponent>(m, "PointLightComponent");                             \
+    auto m_script_component      = py::class_<atcg::ScriptComponent>(m, "ScriptComponent");                                     \
+    auto m_scene_hierarchy_panel = py::class_<atcg::GUI::SceneHierarchyPanel>(m, "SceneHierarchyPanel");                        \
+    auto m_hit_info              = py::class_<atcg::Tracing::HitInfo>(m, "HitInfo");                                            \
+    auto m_utils                 = m.def_submodule("Utils");                                                                    \
+    auto m_draw_mode             = py::enum_<atcg::DrawMode>(m, "DrawMode");                                                    \
+    auto m_cull_mode             = py::enum_<atcg::CullMode>(m, "CullMode");                                                    \
+    auto m_network               = m.def_submodule("Network");                                                                  \
+    auto m_tcp_server            = py::class_<atcg::TCPServer>(m_network, "TCPServer");                                         \
+    auto m_tcp_client            = py::class_<atcg::TCPClient>(m_network, "TCPClient");                                         \
+    auto m_performance_panel     = py::class_<atcg::PerformancePanel>(m, "PerformancePanel");                                   \
     auto m_scriptengine =                                                                                                       \
         py::class_<atcg::PythonScriptEngine, atcg::ref_ptr<atcg::PythonScriptEngine>>(m, "ScriptEngine");                       \
     auto m_script = py::class_<atcg::PythonScript, atcg::ref_ptr<atcg::PythonScript>>(m, "Script");
@@ -1379,9 +1378,9 @@ inline void defineBindings(py::module_& m)
 
     m_scene_hierarchy_panel.def(py::init<>())
         .def(py::init<const atcg::ref_ptr<atcg::Scene>&>(), "scene"_a)
-        .def("renderPanel", &atcg::SceneHierarchyPanel<atcg::ComponentGUIHandler>::renderPanel<>)
-        .def("selectEntity", &atcg::SceneHierarchyPanel<atcg::ComponentGUIHandler>::selectEntity, "entity"_a)
-        .def("getSelectedEntity", &atcg::SceneHierarchyPanel<atcg::ComponentGUIHandler>::getSelectedEntity);
+        .def("renderPanel", &atcg::GUI::SceneHierarchyPanel::renderPanel<>)
+        .def("selectEntity", &atcg::GUI::SceneHierarchyPanel::selectEntity, "entity"_a)
+        .def("getSelectedEntity", &atcg::GUI::SceneHierarchyPanel::getSelectedEntity);
 
     m_hit_info.def_readonly("hit", &atcg::Tracing::HitInfo::hit)
         .def_readonly("position", &atcg::Tracing::HitInfo::p)

--- a/atcg_lib/src/DataStructure/PerformancePanel.cpp
+++ b/atcg_lib/src/DataStructure/PerformancePanel.cpp
@@ -6,6 +6,8 @@
 
 namespace atcg
 {
+namespace GUI
+{
 void PerformancePanel::renderPanel(bool& show_window)
 {
 #ifndef ATCG_HEADLESS
@@ -57,4 +59,5 @@ void PerformancePanel::registerFrameTime(const float frame_time)
     _frame_time_collection.addSample(frame_time * 1000.0f);
     ++_frame_id;
 }
+}    // namespace GUI
 }    // namespace atcg

--- a/docs/source/DataStructure/PerformancePanel.rst
+++ b/docs/source/DataStructure/PerformancePanel.rst
@@ -1,6 +1,6 @@
 PerformancePanel
 ================
 
-.. doxygenclass:: atcg::PerformancePanel
+.. doxygenclass:: atcg::GUI::PerformancePanel
    :members:
    :undoc-members:

--- a/docs/source/Scene/SceneHierarchyPanel.rst
+++ b/docs/source/Scene/SceneHierarchyPanel.rst
@@ -1,9 +1,11 @@
 Scene Hierarchy Panel
 =====================
 
-.. doxygenclass:: atcg::SceneHierarchyPanel
+.. doxygenclass:: atcg::GUI::SceneHierarchyPanel
    :members:
    :undoc-members:
-.. doxygenclass:: atcg::ComponentGUIHandler
+.. doxygenstruct:: atcg::GUI::ComponentGUIRenderer
    :members:
    :undoc-members:
+.. doxygenfunction:: atcg::GUI::displayMaterial
+   :project: ATCGLIB

--- a/src/Cloth/source.cpp
+++ b/src/Cloth/source.cpp
@@ -90,7 +90,7 @@ public:
         atcg::Entity camera_entity = scene->createEntity("EditorCamera");
         camera_entity.addComponent<atcg::EditorCameraComponent>(camera_controller->getCamera());
 
-        panel = atcg::SceneHierarchyPanel(scene);
+        panel = atcg::GUI::SceneHierarchyPanel(scene);
     }
 
     // This gets called each frame
@@ -156,7 +156,7 @@ public:
                 comp.shader->setFloat("checker_size", 0.1f);
 
                 hovered_entity = {entt::null, scene.get()};
-                panel          = atcg::SceneHierarchyPanel(scene);
+                panel          = atcg::GUI::SceneHierarchyPanel(scene);
                 panel.selectEntity(hovered_entity);
             }
 
@@ -263,7 +263,7 @@ private:
     atcg::ref_ptr<atcg::Graph> plane;
     atcg::ref_ptr<atcg::Shader> checkerboard_shader;
 
-    atcg::SceneHierarchyPanel<atcg::ComponentGUIHandler> panel;
+    atcg::GUI::SceneHierarchyPanel panel;
 
     float time       = 0.0f;
     bool in_viewport = false;

--- a/src/Deferred/source.cpp
+++ b/src/Deferred/source.cpp
@@ -335,7 +335,7 @@ public:
         light.intensity  = 10.0f;
         point_light.addComponent<atcg::TransformComponent>(glm::vec3(0, 5, 0));
 
-        panel = atcg::SceneHierarchyPanel<atcg::ComponentGUIHandler>(scene);
+        panel = atcg::GUI::SceneHierarchyPanel(scene);
 
         const auto& window = atcg::Application::get()->getWindow();
         float aspect_ratio = (float)window->getWidth() / (float)window->getHeight();
@@ -491,7 +491,7 @@ private:
 
     atcg::ref_ptr<atcg::Graph> plane;
 
-    atcg::SceneHierarchyPanel<atcg::ComponentGUIHandler> panel;
+    atcg::GUI::SceneHierarchyPanel panel;
 
     float time       = 0.0f;
     bool in_viewport = false;

--- a/src/PBR/source.cpp
+++ b/src/PBR/source.cpp
@@ -35,7 +35,7 @@ public:
             script.script->onAttach();
         }
 
-        panel = atcg::SceneHierarchyPanel<atcg::ComponentGUIHandler>(scene);
+        panel = atcg::GUI::SceneHierarchyPanel(scene);
 
         if(atcg::VR::isVRAvailable())
         {
@@ -346,7 +346,7 @@ private:
 
     atcg::ref_ptr<atcg::Graph> plane;
 
-    atcg::SceneHierarchyPanel<atcg::ComponentGUIHandler> panel;
+    atcg::GUI::SceneHierarchyPanel panel;
     atcg::PerformancePanel performance_panel;
     bool show_performance = false;
 

--- a/src/PBR/source.cpp
+++ b/src/PBR/source.cpp
@@ -347,7 +347,7 @@ private:
     atcg::ref_ptr<atcg::Graph> plane;
 
     atcg::GUI::SceneHierarchyPanel panel;
-    atcg::PerformancePanel performance_panel;
+    atcg::GUI::PerformancePanel performance_panel;
     bool show_performance = false;
 
     float time       = 0.0f;


### PR DESCRIPTION
Similar to the Serialization code, Component GUI rendering is now handled by individual structs that can be extended via template specialization for easier integration of custom components.