### PR TITLE
Fix garbage collection of Render Graph resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added MeshLight component
 - Added a class to sample textures from host/device code
 - Added vector traits for compile time glm checks
+- Added an application counter
 
 ### Changed
 
@@ -71,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed rendering of InstanceRenderComponent
 - Fixed Revision of Camera Components
 - Fixed mip level when copying texture3d
+- Fixed garbage collection of Render Graph resources based on application counter and reduce how many frames are cached
 
 ## [0.2.1-beta]
 

--- a/atcg_lib/include/Core/Application.h
+++ b/atcg_lib/include/Core/Application.h
@@ -133,6 +133,13 @@ public:
      */
     virtual void run();
 
+    /**
+     * @brief Get the counter of the application loop
+     *
+     * @return The frame count
+     */
+    ATCG_INLINE uint64_t getApplicationCounter() const { return _application_counter; }
+
 private:
     bool onWindowClose(WindowCloseEvent* e);
     bool onWindowResize(WindowResizeEvent* e);
@@ -151,6 +158,8 @@ private:
     ImGuiLayer* _imgui_layer;
 #endif
     LayerStack _layer_stack;
+
+    uint64_t _application_counter = 0;
 
     // Systems
     atcg::ref_ptr<AssetManagerSystem> _asset_manager;

--- a/atcg_lib/include/DataStructure/ResourcePool.h
+++ b/atcg_lib/include/DataStructure/ResourcePool.h
@@ -76,7 +76,7 @@ private:
     struct ResourceEntry
     {
         atcg::ref_ptr<Framebuffer> fbo;
-        uint32_t live_time = 0;
+        uint64_t live_time = 0;
     };
     std::unordered_map<ResourceDescription, ResourceEntry, ResourceDescriptionHash, ResourceDescriptionEqual>
         _resources;

--- a/atcg_lib/include/Renderer/RenderGraph.h
+++ b/atcg_lib/include/Renderer/RenderGraph.h
@@ -100,6 +100,13 @@ public:
     ATCG_INLINE bool isCompiled() const { return _compiled; }
 
     /**
+     * @brief Trigger the garbage collection for each render pass.
+     * This function increases the lifetime of garbage collected objects and destroys them if the maximum life time is
+     * reached.
+     */
+    void garbageCollect();
+
+    /**
      * @brief Compile the graph if it is not compiled, otherwise NOP
      *
      * @param ctx The compile context

--- a/atcg_lib/include/Renderer/RenderPass.h
+++ b/atcg_lib/include/Renderer/RenderPass.h
@@ -156,6 +156,13 @@ public:
      */
     ATCG_INLINE const std::string& name() const { return _name; }
 
+    /**
+     * @brief Garbage collect.
+     * This function increases the lifetime of garbage collected objects and destroys them if the maximum life time is
+     * reached.
+     */
+    ATCG_INLINE void garbageCollect() { _pool.garbageCollect(); }
+
     ATCG_INLINE atcg::ref_ptr<Framebuffer>
     prepareFramebuffer(Dictionary& context, const Dictionary& inputs, Dictionary& data, Dictionary& outputs)
     {
@@ -187,8 +194,6 @@ public:
 
                 (*target)->use();
                 target_fb = *target;
-
-                _pool.garbageCollect();
             }
             break;
         }

--- a/atcg_lib/src/Core/Application.cpp
+++ b/atcg_lib/src/Core/Application.cpp
@@ -181,6 +181,7 @@ void Application::run()
         VR::onUpdate(delta_time);
         VR::emitEvents();
         _window->onUpdate();
+        ++_application_counter;
 
 #ifndef ATCG_HEADLESS
         glm::ivec2 viewport_size = _imgui_layer->getViewportSize();

--- a/atcg_lib/src/DataStructure/ResourcePool.cpp
+++ b/atcg_lib/src/DataStructure/ResourcePool.cpp
@@ -1,6 +1,7 @@
 #include <DataStructure/ResourcePool.h>
+#include <Core/Application.h>
 
-#define MAX_LIVE_TIME 500
+#define MAX_LIVE_TIME 1
 
 namespace atcg
 {
@@ -15,21 +16,22 @@ atcg::ref_ptr<Framebuffer> ResourcePool::acquireFramebuffer(ResourceDescription 
                    desc.spec.height,
                    desc.spec.depth);
         auto fbo = Framebuffer::create(desc.spec);
-        _resources.insert(std::make_pair(desc, ResourceEntry {fbo, 0}));
+        _resources.insert(std::make_pair(desc, ResourceEntry {fbo, Application::get()->getApplicationCounter()}));
         return fbo;
     }
 
-    it->second.live_time = 0;
+    it->second.live_time = Application::get()->getApplicationCounter();
     return it->second.fbo;
 }
 
 void ResourcePool::garbageCollect()
 {
+    uint64_t current_counter = Application::get()->getApplicationCounter();
     for(auto it = _resources.begin(); it != _resources.end();)
     {
-        ++(it->second.live_time);
+        uint64_t live_time = current_counter - it->second.live_time;
 
-        if(it->second.live_time > MAX_LIVE_TIME)
+        if(live_time > MAX_LIVE_TIME)
         {
             ATCG_TRACE("Deleted Framebuffer resource {} with resolution {} x {} x {}",
                        it->first.name,

--- a/atcg_lib/src/Renderer/RenderGraph.cpp
+++ b/atcg_lib/src/Renderer/RenderGraph.cpp
@@ -134,6 +134,13 @@ void RenderGraph::exportToDOT(const std::string& path) const
     out << "}\n";
 }
 
+void RenderGraph::garbageCollect()
+{
+    for(auto& pass: _passes)
+    {
+        pass->garbageCollect();
+    }
+}
 
 atcg::ref_ptr<RenderGraph> createStandardGraph()
 {

--- a/atcg_lib/src/Scene/Scene.cpp
+++ b/atcg_lib/src/Scene/Scene.cpp
@@ -160,6 +160,7 @@ void Scene::draw(Dictionary& context)
 
     impl->_render_graph->ensureCompiled(context);
     impl->_render_graph->execute(context);
+    impl->_render_graph->garbageCollect();
 }
 
 void Scene::draw(const atcg::ref_ptr<Camera>& camera, const atcg::ref_ptr<Framebuffer>& target)


### PR DESCRIPTION
Render Graph resources were kept for 500 invocations of the graph. This can lead to an excessive amount of cached framebuffers leading to freezes. This time was reduced to one frame and is now application frame driven instead of graph invocation based.
Closes  #89 