### PR TITLE
Fix crash when trying to add path tracing components to an entity using the GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed mip level when copying texture3d
 - Fixed garbage collection of Render Graph resources based on application counter and reduce how many frames are cached
 - Fixed tonemapping of background color
+- Fixed crash when trying to add path tracing components to entities via the gui
 
 ## [0.2.1-beta]
 

--- a/atcg_lib/include/Scene/ComponentGUIHandler.h
+++ b/atcg_lib/include/Scene/ComponentGUIHandler.h
@@ -45,6 +45,11 @@ struct ComponentGUIRenderer
     void draw_component(const atcg::ref_ptr<Scene>& scene, Entity entity, T& component) const {}
 };
 
+template<typename T>
+struct is_gui_addable : std::true_type
+{
+};
+
 #define ATCG_DECLARE_COMPONENT_GUI_RENDERER(ComponentType)                                                             \
     template<>                                                                                                         \
     struct ComponentGUIRenderer<ComponentType>                                                                         \
@@ -115,6 +120,8 @@ template<typename T>
 ATCG_INLINE void displayAddComponentEntry(const atcg::ref_ptr<atcg::Scene>& scene, Entity entity)
 {
 #ifndef ATCG_HEADLESS
+    if constexpr(!is_gui_addable<T>::value) return;
+
     if(!entity.hasComponent<T>())
     {
         if(ImGui::MenuItem(T::toString()))

--- a/atcg_lib/platform/optix/include/BSDF/BSDF.h
+++ b/atcg_lib/platform/optix/include/BSDF/BSDF.h
@@ -78,6 +78,10 @@ struct BSDFComponent
 #ifndef __CUDACC__
 namespace GUI
 {
+template<>
+struct is_gui_addable<BSDFComponent> : std::false_type
+{
+};
 ATCG_DECLARE_COMPONENT_GUI_RENDERER(BSDFComponent);
 }    // namespace GUI
 #endif

--- a/atcg_lib/platform/optix/include/Emitter/Emitter.h
+++ b/atcg_lib/platform/optix/include/Emitter/Emitter.h
@@ -78,6 +78,10 @@ struct EmitterComponent
 #ifndef __CUDACC__
 namespace GUI
 {
+template<>
+struct is_gui_addable<EmitterComponent> : std::false_type
+{
+};
 ATCG_DECLARE_COMPONENT_GUI_RENDERER(EmitterComponent);
 }    // namespace GUI
 #endif

--- a/atcg_lib/platform/optix/include/Medium/Medium.h
+++ b/atcg_lib/platform/optix/include/Medium/Medium.h
@@ -74,6 +74,10 @@ struct MediumComponent
 #ifndef __CUDACC__
 namespace GUI
 {
+template<>
+struct is_gui_addable<MediumComponent> : std::false_type
+{
+};
 ATCG_DECLARE_COMPONENT_GUI_RENDERER(MediumComponent);
 }    // namespace GUI
 #endif


### PR DESCRIPTION
Fix crash when trying to add path tracing components to an entity using the GUI