### PR TITLE
Add order dependent transparency and bounding box culling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added simple camera exposure model
 - Added optix as submodule. The pathtracing backend is now always built when CUDA is available
 - Added depth pass for meshes
+- Added bounding boxes to geometries
+- Added Transparency component to mark transparent objects
+- Added order dependent transparency rendering (sorting of transparent objects)
+- Added frustum culling based on bounding boxes
 
 ### Changed
 

--- a/atcg_lib/include/DataStructure/BoundingBox.h
+++ b/atcg_lib/include/DataStructure/BoundingBox.h
@@ -12,4 +12,32 @@ struct BoundingBox
     glm::vec3 min = glm::vec3(-1);
     glm::vec3 max = glm::vec3(1);
 };
+
+ATCG_INLINE BoundingBox operator+(const BoundingBox& a, const BoundingBox& b)
+{
+    BoundingBox result;
+    result.min = glm::min(a.min, b.min);
+    result.max = glm::max(a.max, b.max);
+    return result;
+}
+
+ATCG_INLINE BoundingBox transformBoundingBox(const BoundingBox& bbox, const glm::mat4& transform)
+{
+    glm::vec3 min = transform * glm::vec4(bbox.min, 1.0f);
+    glm::vec3 max = transform * glm::vec4(bbox.max, 1.0f);
+
+    BoundingBox result;
+    result.min = glm::min(min, max);
+    result.max = glm::max(min, max);
+    return result;
+}
+
+ATCG_INLINE glm::mat4 boundingBoxToModelMatrix(const BoundingBox& bbox)
+{
+    glm::vec3 center = (bbox.min + bbox.max) * 0.5f;
+    glm::vec3 scale  = bbox.max - bbox.min;
+
+    glm::mat4 model = glm::translate(center) * glm::scale(scale);
+    return model;
+}
 }    // namespace atcg

--- a/atcg_lib/include/DataStructure/BoundingBox.h
+++ b/atcg_lib/include/DataStructure/BoundingBox.h
@@ -45,6 +45,12 @@ ATCG_INLINE glm::mat4 boundingBoxToModelMatrix(const BoundingBox& bbox)
     return model;
 }
 
+ATCG_INLINE bool insideBoundingBox(const glm::vec3& point, const BoundingBox& bbox)
+{
+    return (point.x >= bbox.min.x && point.x <= bbox.max.x) && (point.y >= bbox.min.y && point.y <= bbox.max.y) &&
+           (point.z >= bbox.min.z && point.z <= bbox.max.z);
+}
+
 ATCG_INLINE std::array<glm::vec3, 8> getBoundingBoxCorners(const BoundingBox& bbox)
 {
     std::array<glm::vec3, 8> corners;
@@ -63,6 +69,11 @@ ATCG_INLINE std::array<glm::vec3, 8> getBoundingBoxCorners(const BoundingBox& bb
 
 ATCG_INLINE bool isVisible(const atcg::ref_ptr<Camera>& camera, const BoundingBox& bbox)
 {
+    if(insideBoundingBox(camera->getPosition(), bbox))
+    {
+        return true;
+    }
+
     std::array<glm::vec3, 8> corners = getBoundingBoxCorners(bbox);
     for(int i = 0; i < 8; ++i)
     {
@@ -73,5 +84,6 @@ ATCG_INLINE bool isVisible(const atcg::ref_ptr<Camera>& camera, const BoundingBo
     }
     return false;
 }
+
 }    // namespace Utils
 }    // namespace atcg

--- a/atcg_lib/include/DataStructure/BoundingBox.h
+++ b/atcg_lib/include/DataStructure/BoundingBox.h
@@ -69,20 +69,33 @@ ATCG_INLINE std::array<glm::vec3, 8> getBoundingBoxCorners(const BoundingBox& bb
 
 ATCG_INLINE bool isVisible(const atcg::ref_ptr<Camera>& camera, const BoundingBox& bbox)
 {
-    if(insideBoundingBox(camera->getPosition(), bbox))
-    {
-        return true;
-    }
+    glm::mat4 view_projection = glm::transpose(camera->getViewProjection());
+    std::array<glm::vec4, 6> planes;
+    planes[0] = view_projection[3] + view_projection[0];    // left
+    planes[1] = view_projection[3] - view_projection[0];    // right
+    planes[2] = view_projection[3] + view_projection[1];    // bottom
+    planes[3] = view_projection[3] - view_projection[1];    // top
+    planes[4] = view_projection[3] + view_projection[2];    // near
+    planes[5] = view_projection[3] - view_projection[2];    // far
 
-    std::array<glm::vec3, 8> corners = getBoundingBoxCorners(bbox);
-    for(int i = 0; i < 8; ++i)
+    for(const auto& plane: planes)
     {
-        if(camera->isPointInFrustum(corners[i]))
+        glm::vec3 normal = glm::vec3(plane);
+        float length     = glm::length(normal);
+        float distance   = plane.w / length;
+        normal           = normal / length;
+
+        glm::vec3 positive_vertex = bbox.min;
+        if(normal.x >= 0) positive_vertex.x = bbox.max.x;
+        if(normal.y >= 0) positive_vertex.y = bbox.max.y;
+        if(normal.z >= 0) positive_vertex.z = bbox.max.z;
+
+        if((glm::dot(normal, positive_vertex) + distance) < 0)
         {
-            return true;
+            return false;
         }
     }
-    return false;
+    return true;
 }
 
 }    // namespace Utils

--- a/atcg_lib/include/DataStructure/BoundingBox.h
+++ b/atcg_lib/include/DataStructure/BoundingBox.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Core/glm.h>
+#include <array>
+#include <Renderer/Camera.h>
 
 namespace atcg
 {
@@ -21,6 +23,8 @@ ATCG_INLINE BoundingBox operator+(const BoundingBox& a, const BoundingBox& b)
     return result;
 }
 
+namespace Utils
+{
 ATCG_INLINE BoundingBox transformBoundingBox(const BoundingBox& bbox, const glm::mat4& transform)
 {
     glm::vec3 min = transform * glm::vec4(bbox.min, 1.0f);
@@ -40,4 +44,34 @@ ATCG_INLINE glm::mat4 boundingBoxToModelMatrix(const BoundingBox& bbox)
     glm::mat4 model = glm::translate(center) * glm::scale(scale);
     return model;
 }
+
+ATCG_INLINE std::array<glm::vec3, 8> getBoundingBoxCorners(const BoundingBox& bbox)
+{
+    std::array<glm::vec3, 8> corners;
+
+    corners[0] = glm::vec3(bbox.min.x, bbox.min.y, bbox.min.z);
+    corners[1] = glm::vec3(bbox.max.x, bbox.min.y, bbox.min.z);
+    corners[2] = glm::vec3(bbox.max.x, bbox.max.y, bbox.min.z);
+    corners[3] = glm::vec3(bbox.min.x, bbox.max.y, bbox.min.z);
+    corners[4] = glm::vec3(bbox.min.x, bbox.min.y, bbox.max.z);
+    corners[5] = glm::vec3(bbox.max.x, bbox.min.y, bbox.max.z);
+    corners[6] = glm::vec3(bbox.max.x, bbox.max.y, bbox.max.z);
+    corners[7] = glm::vec3(bbox.min.x, bbox.max.y, bbox.max.z);
+
+    return corners;
+}
+
+ATCG_INLINE bool isVisible(const atcg::ref_ptr<Camera>& camera, const BoundingBox& bbox)
+{
+    std::array<glm::vec3, 8> corners = getBoundingBoxCorners(bbox);
+    for(int i = 0; i < 8; ++i)
+    {
+        if(camera->isPointInFrustum(corners[i]))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+}    // namespace Utils
 }    // namespace atcg

--- a/atcg_lib/include/DataStructure/Graph.h
+++ b/atcg_lib/include/DataStructure/Graph.h
@@ -12,7 +12,7 @@
 #include <DataStructure/GraphDefinitions.h>
 #include <DataStructure/GraphLoader.h>
 #include <Asset/Asset.h>
-#include <DataStructure/Boundingbox.h>
+#include <DataStructure/BoundingBox.h>
 
 namespace atcg
 {

--- a/atcg_lib/include/DataStructure/Graph.h
+++ b/atcg_lib/include/DataStructure/Graph.h
@@ -12,6 +12,7 @@
 #include <DataStructure/GraphDefinitions.h>
 #include <DataStructure/GraphLoader.h>
 #include <Asset/Asset.h>
+#include <DataStructure/Boundingbox.h>
 
 namespace atcg
 {
@@ -366,6 +367,20 @@ public:
      * @return The type
      */
     GraphType type() const;
+
+    /**
+     * @brief Get the bounding box of the graph
+     *
+     * @return Bounding Box
+     */
+    BoundingBox getBoundingBox() const;
+
+    /**
+     * @brief Update the bounding box of the graph based on the vertex positions.
+     * This may be useful if the vertex positions are updated directly via the getPositions() function and the bounding
+     * box needs to be updated accordingly.
+     */
+    void updateBoundingBox();
 
     /**
      * @brief Get a tensor of vertex positions on the specified device.

--- a/atcg_lib/include/Renderer/Camera.h
+++ b/atcg_lib/include/Renderer/Camera.h
@@ -51,6 +51,30 @@ public:
      */
     virtual atcg::ref_ptr<Camera> copy() const = 0;
 
+    /**
+     * @brief Transform a point from world space to camera space
+     *
+     * @param point The point in world space
+     * @return The point in camera space
+     */
+    virtual glm::vec3 transformToCameraSpace(const glm::vec3& point) const = 0;
+
+    /**
+     * @brief Transform a point from world space to normalized device coordinates (NDC)
+     *
+     * @param point The point in world space
+     * @return The point in NDC
+     */
+    virtual glm::vec3 transformToNormalizedDeviceCoordinates(const glm::vec3& point) const = 0;
+
+    /**
+     * @brief Check if a point is inside the camera frustum
+     *
+     * @param point The point in world space
+     * @return true if the point is inside the frustum, false otherwise
+     */
+    virtual bool isPointInFrustum(const glm::vec3& point) const = 0;
+
     ATCG_INLINE const CameraExtrinsics& getExtrinsics() const { return _extrinsics; }
 
     ATCG_INLINE const CameraIntrinsics& getIntrinsics() const { return _intrinsics; }

--- a/atcg_lib/include/Renderer/OrthographicCamera.h
+++ b/atcg_lib/include/Renderer/OrthographicCamera.h
@@ -63,6 +63,30 @@ public:
     ATCG_INLINE virtual glm::vec3 getDirection() const override { return glm::vec3(0, 0, -1); }
 
     /**
+     * @brief Transform a point from world space to camera space
+     *
+     * @param point The point in world space
+     * @return The point in camera space
+     */
+    virtual glm::vec3 transformToCameraSpace(const glm::vec3& point) const override;
+
+    /**
+     * @brief Transform a point from world space to normalized device coordinates (NDC)
+     *
+     * @param point The point in world space
+     * @return The point in NDC
+     */
+    virtual glm::vec3 transformToNormalizedDeviceCoordinates(const glm::vec3& point) const override;
+
+    /**
+     * @brief Check if a point is inside the camera frustum
+     *
+     * @param point The point in world space
+     * @return true if the point is inside the frustum, false otherwise
+     */
+    virtual bool isPointInFrustum(const glm::vec3& point) const override;
+
+    /**
      * @brief Set the Projection
      *
      * @param left

--- a/atcg_lib/include/Renderer/PerspectiveCamera.h
+++ b/atcg_lib/include/Renderer/PerspectiveCamera.h
@@ -160,6 +160,30 @@ public:
     ATCG_INLINE void setFar(float far_plane) { _intrinsics.setFar(far_plane); }
 
     /**
+     * @brief Transform a point from world space to camera space
+     *
+     * @param point The point in world space
+     * @return The point in camera space
+     */
+    virtual glm::vec3 transformToCameraSpace(const glm::vec3& point) const override;
+
+    /**
+     * @brief Transform a point from world space to normalized device coordinates (NDC)
+     *
+     * @param point The point in world space
+     * @return The point in NDC
+     */
+    virtual glm::vec3 transformToNormalizedDeviceCoordinates(const glm::vec3& point) const override;
+
+    /**
+     * @brief Check if a point is inside the camera frustum
+     *
+     * @param point The point in world space
+     * @return true if the point is inside the frustum, false otherwise
+     */
+    virtual bool isPointInFrustum(const glm::vec3& point) const override;
+
+    /**
      * @brief Create a copy of the camera
      *
      * @return The deep copy

--- a/atcg_lib/include/Renderer/RenderPasses/ForwardPass.h
+++ b/atcg_lib/include/Renderer/RenderPasses/ForwardPass.h
@@ -43,5 +43,11 @@ public:
     ForwardPass(const RenderTargetDesc& desc = {});
 
 private:
+    struct TransparentRenderData
+    {
+        atcg::Entity entity;
+        float distance_to_camera;
+    };
+    std::vector<TransparentRenderData> _transparent_entities;
 };
 }    // namespace atcg

--- a/atcg_lib/include/Scene/Components.h
+++ b/atcg_lib/include/Scene/Components.h
@@ -20,3 +20,4 @@
 #include <Scene/Components/RenderComponent.h>
 #include <Scene/Components/ScriptComponent.h>
 #include <Scene/Components/TransformComponent.h>
+#include <Scene/Components/TransparencyComponent.h>

--- a/atcg_lib/include/Scene/Components/GeometryComponent.h
+++ b/atcg_lib/include/Scene/Components/GeometryComponent.h
@@ -4,6 +4,7 @@
 #include <DataStructure/Graph.h>
 #include <Scene/ComponentGUIHandler.h>
 #include <Scene/ComponentSerializer.h>
+#include <Scene/ComponentRenderer.h>
 
 namespace atcg
 {
@@ -25,10 +26,14 @@ struct GeometryComponent
 
     ATCG_INLINE atcg::ref_ptr<Graph> graph() const { return AssetManager::getAsset<Graph>(graph_handle); }
 
+    bool draw_bounding_box = false;
+
     AssetHandle graph_handle;
 
     static ATCG_CONSTEXPR ATCG_INLINE const char* toString() { return "Geometry"; }
 };
+
+ATCG_DECLARE_COMPONENT_RENDERER(GeometryComponent);
 
 namespace Serialization
 {

--- a/atcg_lib/include/Scene/Components/TransparencyComponent.h
+++ b/atcg_lib/include/Scene/Components/TransparencyComponent.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <Scene/ComponentSerializer.h>
+#include <Scene/ComponentGUIHandler.h>
+
+namespace atcg
+{
+struct TransparencyComponent
+{
+    TransparencyComponent() = default;
+
+    TransparencyComponent(bool transparent) : transparent(transparent) {}
+
+    bool transparent = true;
+
+    static ATCG_CONSTEXPR ATCG_INLINE const char* toString() { return "Transparency"; }
+};
+
+namespace Serialization
+{
+ATCG_DECLARE_COMPONENT_SERIALIZER(TransparencyComponent);
+}
+
+namespace GUI
+{
+ATCG_DECLARE_COMPONENT_GUI_RENDERER(TransparencyComponent);
+}
+}    // namespace atcg

--- a/atcg_lib/src/Asset/AssetExporter.cpp
+++ b/atcg_lib/src/Asset/AssetExporter.cpp
@@ -83,14 +83,15 @@ ATCG_INLINE void serialize_opaque_material_ver1(const atcg::ref_ptr<OpaqueMateri
     else
     {
         auto data         = diffuse_texture->getData(atcg::CPU);
-        glm::u8vec3 color = {data.index({0, 0, 0}).item<uint8_t>(),
+        glm::u8vec4 color = {data.index({0, 0, 0}).item<uint8_t>(),
                              data.index({0, 0, 1}).item<uint8_t>(),
-                             data.index({0, 0, 2}).item<uint8_t>()};
+                             data.index({0, 0, 2}).item<uint8_t>(),
+                             data.index({0, 0, 3}).item<uint8_t>()};
 
-        glm::vec3 c(color);
+        glm::vec4 c(color);
         c = c / 255.0f;
 
-        material_json[DIFFUSE_KEY] = nlohmann::json::array({c.x, c.y, c.z});
+        material_json[DIFFUSE_KEY] = nlohmann::json::array({c.x, c.y, c.z, c.w});
     }
 
     if(use_normal_texture)
@@ -181,14 +182,15 @@ ATCG_INLINE void serialize_dielectric_material_ver1(const atcg::ref_ptr<Dielectr
     else
     {
         auto data         = diffuse_texture->getData(atcg::CPU);
-        glm::u8vec3 color = {data.index({0, 0, 0}).item<uint8_t>(),
+        glm::u8vec4 color = {data.index({0, 0, 0}).item<uint8_t>(),
                              data.index({0, 0, 1}).item<uint8_t>(),
-                             data.index({0, 0, 2}).item<uint8_t>()};
+                             data.index({0, 0, 2}).item<uint8_t>(),
+                             data.index({0, 0, 3}).item<uint8_t>()};
 
-        glm::vec3 c(color);
+        glm::vec4 c(color);
         c = c / 255.0f;
 
-        material_json[DIFFUSE_KEY] = nlohmann::json::array({c.x, c.y, c.z});
+        material_json[DIFFUSE_KEY] = nlohmann::json::array({c.x, c.y, c.z, c.w});
     }
 
     if(use_roughness_texture)

--- a/atcg_lib/src/Asset/AssetImporter.cpp
+++ b/atcg_lib/src/Asset/AssetImporter.cpp
@@ -40,7 +40,14 @@ atcg::ref_ptr<OpaqueMaterial> deserializeOpaqueMaterial_ver1(const std::filesyst
     if(material_node.contains(DIFFUSE_KEY))
     {
         std::vector<float> diffuse_color = material_node[DIFFUSE_KEY];
-        material->setDiffuseColor(glm::vec4(glm::make_vec3(diffuse_color.data()), 1.0f));
+        if(diffuse_color.size() == 3)
+        {
+            material->setDiffuseColor(glm::vec4(glm::make_vec3(diffuse_color.data()), 1.0f));
+        }
+        else if(diffuse_color.size() == 4)
+        {
+            material->setDiffuseColor(glm::make_vec4(diffuse_color.data()));
+        }
     }
     else if(material_node.contains(DIFFUSE_TEXTURE_KEY))
     {
@@ -113,7 +120,14 @@ atcg::ref_ptr<DielectricMaterial> deserializeDielectricMaterial_ver1(const std::
     if(material_node.contains(DIFFUSE_KEY))
     {
         std::vector<float> diffuse_color = material_node[DIFFUSE_KEY];
-        material->setDiffuseColor(glm::vec4(glm::make_vec3(diffuse_color.data()), 1.0f));
+        if(diffuse_color.size() == 3)
+        {
+            material->setDiffuseColor(glm::vec4(glm::make_vec3(diffuse_color.data()), 1.0f));
+        }
+        else if(diffuse_color.size() == 4)
+        {
+            material->setDiffuseColor(glm::make_vec4(diffuse_color.data()));
+        }
     }
     else if(material_node.contains(DIFFUSE_TEXTURE_KEY))
     {

--- a/atcg_lib/src/DataStructure/Graph.cpp
+++ b/atcg_lib/src/DataStructure/Graph.cpp
@@ -1,6 +1,5 @@
 #include <DataStructure/Graph.h>
 #include <DataStructure/TorchUtils.h>
-#include <DataStructure/Boundingbox.h>
 
 namespace atcg
 {

--- a/atcg_lib/src/DataStructure/Graph.cpp
+++ b/atcg_lib/src/DataStructure/Graph.cpp
@@ -1,5 +1,6 @@
 #include <DataStructure/Graph.h>
 #include <DataStructure/TorchUtils.h>
+#include <DataStructure/Boundingbox.h>
 
 namespace atcg
 {
@@ -18,6 +19,7 @@ public:
     void updateVertexBuffer(const torch::Tensor& vertices);
     void updateEdgeBuffer(const torch::Tensor& edges);
     void updateFaceBuffer(const torch::Tensor& indices);
+    void updateBoundingBox(const torch::Tensor& positions);
     torch::Tensor edgesFromIndices(const torch::Tensor& face_indices);
 
     atcg::ref_ptr<VertexBuffer> vertices = nullptr;
@@ -32,6 +34,8 @@ public:
     uint32_t n_faces    = 0;
 
     GraphType type;
+
+    BoundingBox bbox;
 };
 
 Graph::Impl::Impl()
@@ -92,6 +96,9 @@ void Graph::Impl::updateVertexBuffer(const torch::Tensor& pvertices)
         vertices->setData(pvertices.data_ptr(), sizeof(atcg::Vertex) * n);
     }
     n_vertices = n;
+
+    torch::Tensor positions = pvertices.index({Slice(), Slice(0, 3)});
+    updateBoundingBox(positions);
 }
 
 void Graph::Impl::updateEdgeBuffer(const torch::Tensor& pedges)
@@ -147,6 +154,17 @@ void Graph::Impl::updateFaceBuffer(const torch::Tensor& pindices)
     }
 
     n_faces = n;
+}
+
+void Graph::Impl::updateBoundingBox(const torch::Tensor& positions)
+{
+    if(positions.size(0) == 0) return;
+
+    auto min = std::get<0>(positions.min(0));
+    auto max = std::get<0>(positions.max(0));
+
+    bbox.min = glm::vec3(min[0].item<float>(), min[1].item<float>(), min[2].item<float>());
+    bbox.max = glm::vec3(max[0].item<float>(), max[1].item<float>(), max[2].item<float>());
 }
 
 torch::Tensor Graph::Impl::edgesFromIndices(const torch::Tensor& indices)
@@ -611,6 +629,16 @@ torch::Tensor Graph::getFaces(const torch::Device& device) const
         uint32_t* face_pointer = impl->indices->getDevicePointer<uint32_t>();
         return atcg::createDeviceTensorFromPointer<uint32_t>(face_pointer, {n_faces(), 3});
     }
+}
+
+BoundingBox Graph::getBoundingBox() const
+{
+    return impl->bbox;
+}
+
+void Graph::updateBoundingBox()
+{
+    impl->updateBoundingBox(getPositions(atcg::GPU));
 }
 
 void Graph::unmapHostVertexPointer()

--- a/atcg_lib/src/Renderer/OrthographicCamera.cpp
+++ b/atcg_lib/src/Renderer/OrthographicCamera.cpp
@@ -18,6 +18,24 @@ void OrthographicCamera::recalculateProjection()
     _projection = glm::ortho(_left, _right, _bottom, _top);
 }
 
+
+glm::vec3 OrthographicCamera::transformToCameraSpace(const glm::vec3& point) const
+{
+    return point;
+}
+
+glm::vec3 OrthographicCamera::transformToNormalizedDeviceCoordinates(const glm::vec3& point) const
+{
+    glm::vec4 p = _projection * glm::vec4(transformToCameraSpace(point), 1.0f);
+    return glm::vec3(p) / p.w;
+}
+
+bool OrthographicCamera::isPointInFrustum(const glm::vec3& point) const
+{
+    glm::vec3 ndc_point = transformToNormalizedDeviceCoordinates(point);
+    return glm::abs(ndc_point.x) <= 1.0f && glm::abs(ndc_point.y) <= 1.0f && glm::abs(ndc_point.z) <= 1.0f;
+}
+
 atcg::ref_ptr<Camera> OrthographicCamera::copy() const
 {
     return atcg::make_ref<OrthographicCamera>(_left, _right, _bottom, _top);

--- a/atcg_lib/src/Renderer/PerspectiveCamera.cpp
+++ b/atcg_lib/src/Renderer/PerspectiveCamera.cpp
@@ -15,4 +15,22 @@ atcg::ref_ptr<Camera> PerspectiveCamera::copy() const
     return camera;
 }
 
+glm::vec3 PerspectiveCamera::transformToCameraSpace(const glm::vec3& point) const
+{
+    glm::vec4 p = _extrinsics.extrinsicMatrix() * glm::vec4(point, 1.0f);
+    return glm::vec3(p);
+}
+
+glm::vec3 PerspectiveCamera::transformToNormalizedDeviceCoordinates(const glm::vec3& point) const
+{
+    glm::vec4 p = _intrinsics.projection() * glm::vec4(transformToCameraSpace(point), 1.0f);
+    return glm::vec3(p) / p.w;
+}
+
+bool PerspectiveCamera::isPointInFrustum(const glm::vec3& point) const
+{
+    glm::vec3 ndc = transformToNormalizedDeviceCoordinates(point);
+    return ndc.x >= -1.0f && ndc.x <= 1.0f && ndc.y >= -1.0f && ndc.y <= 1.0f && ndc.z >= -1.0f && ndc.z <= 1.0f;
+}
+
 }    // namespace atcg

--- a/atcg_lib/src/Renderer/RenderPasses/ForwardPass.cpp
+++ b/atcg_lib/src/Renderer/RenderPasses/ForwardPass.cpp
@@ -6,6 +6,7 @@
 
 namespace atcg
 {
+
 ForwardPass::ForwardPass(const RenderTargetDesc& desc) : RenderPass(desc, "ForwardPass")
 {
     registerOutput("framebuffer", atcg::make_ref<atcg::ref_ptr<Framebuffer>>(nullptr));
@@ -80,6 +81,7 @@ ForwardPass::ForwardPass(const RenderTargetDesc& desc) : RenderPass(desc, "Forwa
                 }
             }
 
+            this->_transparent_entities.clear();
             for(auto e: view)
             {
                 Entity entity(e, scene.get());
@@ -89,7 +91,38 @@ ForwardPass::ForwardPass(const RenderTargetDesc& desc) : RenderPass(desc, "Forwa
                     renderer.callback(entity, camera);
                 }
 
+                if(entity.hasAnyComponent<TransparencyComponent>() &&
+                   entity.getComponent<TransparencyComponent>().transparent)
+                {
+                    TransformComponent& transform = entity.getComponent<TransformComponent>();
+                    glm::vec3 position            = transform.getPosition();
+                    if(entity.hasComponent<GeometryComponent>())
+                    {
+                        GeometryComponent& geometry = entity.getComponent<GeometryComponent>();
+
+                        BoundingBox bbox = geometry.graph()->getBoundingBox();
+                        bbox             = Utils::transformBoundingBox(bbox, transform.getModel());
+
+                        position = (bbox.min + bbox.max) * 0.5f;
+                    }
+
+                    float distance_to_camera = glm::length(camera->getPosition() - position);
+
+                    this->_transparent_entities.push_back({entity, distance_to_camera});
+                    continue;
+                }
+
                 ComponentRegistry::renderAllComponents(renderer, entity, camera, auxiliary);
+            }
+
+            std::sort(this->_transparent_entities.begin(),
+                      this->_transparent_entities.end(),
+                      [](const TransparentRenderData& a, const TransparentRenderData& b)
+                      { return a.distance_to_camera > b.distance_to_camera; });
+
+            for(const auto& data: this->_transparent_entities)
+            {
+                ComponentRegistry::renderAllComponents(renderer, data.entity, camera, auxiliary);
             }
 
             GraphicsCommand::endRenderPass();

--- a/atcg_lib/src/Scene/Components/EdgeCylinderRenderComponent.cpp
+++ b/atcg_lib/src/Scene/Components/EdgeCylinderRenderComponent.cpp
@@ -39,6 +39,14 @@ void ComponentRenderer<EdgeCylinderRenderComponent>::renderComponent(atcg::Rende
 
     geometry.graph()->unmapAllPointers();
 
+    BoundingBox bbox = geometry.graph()->getBoundingBox();
+    bbox             = Utils::transformBoundingBox(bbox, transform.getModel());
+
+    if(!Utils::isVisible(camera, bbox))
+    {
+        return;
+    }
+
     // Actual rendering of component
     EdgeCylinderRenderComponent renderer = entity.getComponent<EdgeCylinderRenderComponent>();
 

--- a/atcg_lib/src/Scene/Components/EdgeCylinderRenderComponent.cpp
+++ b/atcg_lib/src/Scene/Components/EdgeCylinderRenderComponent.cpp
@@ -85,7 +85,8 @@ void ComponentRenderer<EdgeCylinderRenderComponent>::renderComponent(atcg::Rende
 
         vao_cylinder->pushInstanceBuffer(indices);
 
-        GraphicsPipeline pipeline = GraphicsPipeline().setShader(shader);
+        GraphicsPipeline pipeline = GraphicsPipeline().setShader(shader).setRasterizerState(
+            RasterizerState().setCullMode(CullMode::ATCG_BACK_FACE_CULLING).enableCulling(true).enableCulling(true));
 
         _renderer->drawVAO(vao_cylinder,
                            camera,

--- a/atcg_lib/src/Scene/Components/EdgeRenderComponent.cpp
+++ b/atcg_lib/src/Scene/Components/EdgeRenderComponent.cpp
@@ -38,6 +38,14 @@ void ComponentRenderer<EdgeRenderComponent>::renderComponent(atcg::RendererSyste
 
     geometry.graph()->unmapAllPointers();
 
+    BoundingBox bbox = geometry.graph()->getBoundingBox();
+    bbox             = Utils::transformBoundingBox(bbox, transform.getModel());
+
+    if(!Utils::isVisible(camera, bbox))
+    {
+        return;
+    }
+
     // Actual rendering of component
     EdgeRenderComponent renderer = entity.getComponent<EdgeRenderComponent>();
 

--- a/atcg_lib/src/Scene/Components/GeometryComponent.cpp
+++ b/atcg_lib/src/Scene/Components/GeometryComponent.cpp
@@ -48,8 +48,8 @@ void ComponentRenderer<GeometryComponent>::renderComponent(atcg::RendererSystem*
     GraphicsCommand::bindStorageBuffer(0, points);
 
     BoundingBox bbox = comp.graph()->getBoundingBox();
-    bbox             = transformBoundingBox(bbox, model);
-    model            = boundingBoxToModelMatrix(bbox);
+    bbox             = Utils::transformBoundingBox(bbox, model);
+    model            = Utils::boundingBoxToModelMatrix(bbox);
 
     _renderer->drawVAO(cube->getEdgesArray(), camera, model, pipeline, cube->n_edges());
 }

--- a/atcg_lib/src/Scene/Components/GeometryComponent.cpp
+++ b/atcg_lib/src/Scene/Components/GeometryComponent.cpp
@@ -1,11 +1,58 @@
 #include <Scene/Components/GeometryComponent.h>
 #include <Scene/ComponentRegistry.h>
+#include <Scene/Components/TransformComponent.h>
 #include <Utils/Utils.h>
 
-#define GEOMETRY_KEY "Geometry"
+#define GEOMETRY_KEY          "Geometry"
+#define DRAW_BOUNDING_BOX_KEY "DrawBoundingBox"
 
 namespace atcg
 {
+
+void ComponentRenderer<GeometryComponent>::renderComponent(atcg::RendererSystem* _renderer,
+                                                           Entity entity,
+                                                           const atcg::ref_ptr<Camera>& camera,
+                                                           atcg::Dictionary& auxiliary) const
+{
+    atcg::GeometryComponent& comp = entity.getComponent<GeometryComponent>();
+    if(!comp.draw_bounding_box)
+    {
+        return;
+    }
+
+    if(!comp.graph())
+    {
+        return;
+    }
+
+    if(!entity.hasComponent<TransformComponent>())
+    {
+        return;
+    }
+
+    auto cube                 = AssetManager::getCubeMesh();
+    auto shader               = _renderer->getShaderManager()->getShader("edge");
+    GraphicsPipeline pipeline = GraphicsPipeline()
+                                    .setShader(shader)
+                                    .setPrimitiveTopology(PrimitiveTopology::ATCG_POINTS)
+                                    .setRasterizerState(RasterizerState().enableCulling(false).setLineSize(2.0f));
+
+    uint32_t entity_id = entity.entity_handle();
+    shader->setInt("entityID", entity_id);
+    shader->setVec3("flat_color", glm::vec3(0.0f, 1.0f, 0.0f));
+
+    auto& transform = entity.getComponent<TransformComponent>();
+    glm::mat4 model = transform.getModel();
+
+    auto points = cube->getVerticesBuffer();
+    GraphicsCommand::bindStorageBuffer(0, points);
+
+    BoundingBox bbox = comp.graph()->getBoundingBox();
+    bbox             = transformBoundingBox(bbox, model);
+    model            = boundingBoxToModelMatrix(bbox);
+
+    _renderer->drawVAO(cube->getEdgesArray(), camera, model, pipeline, cube->n_edges());
+}
 
 namespace Serialization
 {
@@ -15,7 +62,8 @@ void ComponentSerializer<GeometryComponent>::serialize_component(const std::stri
                                                                  GeometryComponent& component,
                                                                  nlohmann::json& j) const
 {
-    j[GEOMETRY_KEY] = (uint64_t)component.graph_handle;
+    j[GEOMETRY_KEY]          = (uint64_t)component.graph_handle;
+    j[DRAW_BOUNDING_BOX_KEY] = component.draw_bounding_box;
 }
 
 void ComponentSerializer<GeometryComponent>::deserialize_component(const std::string& file_path,
@@ -28,8 +76,9 @@ void ComponentSerializer<GeometryComponent>::deserialize_component(const std::st
         return;
     }
 
-    auto& geometry        = entity.addComponent<GeometryComponent>();
-    geometry.graph_handle = (AssetHandle)j[GEOMETRY_KEY];
+    auto& geometry             = entity.addComponent<GeometryComponent>();
+    geometry.graph_handle      = (AssetHandle)j[GEOMETRY_KEY];
+    geometry.draw_bounding_box = j.value(DRAW_BOUNDING_BOX_KEY, false);
 }
 
 
@@ -42,13 +91,16 @@ void ComponentGUIRenderer<GeometryComponent>::draw_component(const atcg::ref_ptr
                                                              GeometryComponent& component) const
 {
 #ifndef ATCG_HEADLESS
-    auto new_handle = Utils::displayGraphSelection("geometry", component.graph_handle);
-    bool updated    = (new_handle != component.graph_handle);
+    GeometryComponent copy = component;
+    auto new_handle        = Utils::displayGraphSelection("geometry", copy.graph_handle);
+    bool updated           = (new_handle != copy.graph_handle);
+
+    updated = updated || ImGui::Checkbox("Draw Bounding Box", &copy.draw_bounding_box);
 
     if(updated)
     {
         RevisionStack::startRecording<ComponentEditedRevision<GeometryComponent>>(scene, entity);
-        component.graph_handle = new_handle;
+        component = copy;
         atcg::RevisionStack::endRecording();
     }
 #endif

--- a/atcg_lib/src/Scene/Components/MeshRenderComponent.cpp
+++ b/atcg_lib/src/Scene/Components/MeshRenderComponent.cpp
@@ -79,7 +79,8 @@ void ComponentRenderer<MeshRenderComponent>::renderComponent(atcg::RendererSyste
         shader->setInt("lut", lut_id);
         GraphicsCommand::bindTexture(lut_id, AssetManager::getLUTTexture());
 
-        GraphicsPipeline pipeline = GraphicsPipeline().setShader(shader);
+        GraphicsPipeline pipeline = GraphicsPipeline().setShader(shader).setRasterizerState(
+            RasterizerState().setCullMode(CullMode::ATCG_BACK_FACE_CULLING).enableCulling(true).enableCulling(true));
 
         _renderer->drawVAO(geometry.graph()->getVerticesArray(),
                            camera,

--- a/atcg_lib/src/Scene/Components/MeshRenderComponent.cpp
+++ b/atcg_lib/src/Scene/Components/MeshRenderComponent.cpp
@@ -39,6 +39,14 @@ void ComponentRenderer<MeshRenderComponent>::renderComponent(atcg::RendererSyste
 
     geometry.graph()->unmapAllPointers();
 
+    BoundingBox bbox = geometry.graph()->getBoundingBox();
+    bbox             = Utils::transformBoundingBox(bbox, transform.getModel());
+
+    if(!Utils::isVisible(camera, bbox))
+    {
+        return;
+    }
+
     // Actual rendering of component
     MeshRenderComponent renderer = entity.getComponent<MeshRenderComponent>();
 

--- a/atcg_lib/src/Scene/Components/PointRenderComponent.cpp
+++ b/atcg_lib/src/Scene/Components/PointRenderComponent.cpp
@@ -40,6 +40,14 @@ void ComponentRenderer<PointRenderComponent>::renderComponent(atcg::RendererSyst
 
     geometry.graph()->unmapAllPointers();
 
+    BoundingBox bbox = geometry.graph()->getBoundingBox();
+    bbox             = Utils::transformBoundingBox(bbox, transform.getModel());
+
+    if(!Utils::isVisible(camera, bbox))
+    {
+        return;
+    }
+
     // Actual rendering of component
     PointRenderComponent renderer = entity.getComponent<PointRenderComponent>();
 

--- a/atcg_lib/src/Scene/Components/PointSphereRenderComponent.cpp
+++ b/atcg_lib/src/Scene/Components/PointSphereRenderComponent.cpp
@@ -82,7 +82,8 @@ void ComponentRenderer<PointSphereRenderComponent>::renderComponent(atcg::Render
 
         vao_sphere->pushInstanceBuffer(vbo);
 
-        GraphicsPipeline pipeline = GraphicsPipeline().setShader(shader);
+        GraphicsPipeline pipeline = GraphicsPipeline().setShader(shader).setRasterizerState(
+            RasterizerState().setCullMode(CullMode::ATCG_BACK_FACE_CULLING).enableCulling(true).enableCulling(true));
 
         // _renderer->setPointSize(renderer.point_size);
         _renderer->drawVAO(vao_sphere,

--- a/atcg_lib/src/Scene/Components/PointSphereRenderComponent.cpp
+++ b/atcg_lib/src/Scene/Components/PointSphereRenderComponent.cpp
@@ -40,6 +40,14 @@ void ComponentRenderer<PointSphereRenderComponent>::renderComponent(atcg::Render
 
     geometry.graph()->unmapAllPointers();
 
+    BoundingBox bbox = geometry.graph()->getBoundingBox();
+    bbox             = Utils::transformBoundingBox(bbox, transform.getModel());
+
+    if(!Utils::isVisible(camera, bbox))
+    {
+        return;
+    }
+
     // Actual rendering of component
     PointSphereRenderComponent renderer = entity.getComponent<PointSphereRenderComponent>();
 

--- a/atcg_lib/src/Scene/Components/TransparencyComponent.cpp
+++ b/atcg_lib/src/Scene/Components/TransparencyComponent.cpp
@@ -1,0 +1,60 @@
+#include <Scene/Components/TransparencyComponent.h>
+#include <Scene/ComponentRegistry.h>
+
+#define TRANSPARENCY_KEY "Transparency"
+
+namespace atcg
+{
+namespace Serialization
+{
+void ComponentSerializer<TransparencyComponent>::serialize_component(const std::string& file_path,
+                                                                     const atcg::ref_ptr<Scene>& scene,
+                                                                     Entity entity,
+                                                                     TransparencyComponent& component,
+                                                                     nlohmann::json& j) const
+{
+    j[TRANSPARENCY_KEY] = component.transparent;
+}
+
+void ComponentSerializer<TransparencyComponent>::deserialize_component(const std::string& file_path,
+                                                                       const atcg::ref_ptr<Scene>& scene,
+                                                                       Entity entity,
+                                                                       nlohmann::json& j) const
+{
+    if(!j.contains(TRANSPARENCY_KEY))
+    {
+        return;
+    }
+
+    entity.addOrReplaceComponent<TransparencyComponent>(j[TRANSPARENCY_KEY]);
+}
+
+}    // namespace Serialization
+
+namespace GUI
+{
+void ComponentGUIRenderer<TransparencyComponent>::draw_component(const atcg::ref_ptr<Scene>& scene,
+                                                                 Entity entity,
+                                                                 TransparencyComponent& component) const
+{
+#ifndef ATCG_HEADLESS
+    TransparencyComponent copy = component;
+
+    bool updated = ImGui::Checkbox("Transparent", &copy.transparent);
+
+    if(updated)
+    {
+        RevisionStack::startRecording<ComponentEditedRevision<TransparencyComponent>>(scene, entity);
+        component = copy;
+        atcg::RevisionStack::endRecording();
+    }
+#endif
+}
+}    // namespace GUI
+
+
+ATCG_REGISTER_COMPONENT_DRAW(TransparencyComponent);
+ATCG_REGISTER_COMPONENT_SERIALIZATION(TransparencyComponent);
+ATCG_REGISTER_COMPONENT_STORE(TransparencyComponent);
+
+}    // namespace atcg


### PR DESCRIPTION
Added a Transparency component that can be added to entites to mark them as "transparent". Transparent objects are separated into an additional render pass, sorted by distance to camera, to improve transparent objects. Furthermore, view frustum culling is performed in the rendering of components to improve performance.